### PR TITLE
feat: credential setup and management (spec 002)

### DIFF
--- a/.claude/hooks/auto-judge.sh
+++ b/.claude/hooks/auto-judge.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# Hook: Auto-invoke Codex judge when builder sets state to ready_for_judge
+#
+# Fires on PostToolUse for Write and Edit tools.
+# Checks if the file is a status.json in agent-loop/ and if state is ready_for_judge.
+# If so, extracts task_id and round, then runs codex exec in the background.
+#
+# Override the Codex binary path with CODEX_CLI env var if needed.
+# Logs to /tmp/codex-judge-<task-id>-round-<N>.log
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Get the file path from tool input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Exit early if no file path or not a status.json in agent-loop/
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+if ! echo "$FILE_PATH" | grep -qE 'agent-loop/[^/]+/status\.json$'; then
+  exit 0
+fi
+
+# Resolve to absolute path if relative
+if [[ "$FILE_PATH" != /* ]]; then
+  CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+  if [ -n "$CWD" ]; then
+    FILE_PATH="$CWD/$FILE_PATH"
+  fi
+fi
+
+# Read the actual file to check state
+if [ ! -f "$FILE_PATH" ]; then
+  exit 0
+fi
+
+STATE=$(jq -r '.state // empty' "$FILE_PATH")
+TASK_ID=$(jq -r '.task_id // empty' "$FILE_PATH")
+PHASE=$(jq -r '.phase // empty' "$FILE_PATH")
+ROUND=$(jq -r '.round // empty' "$FILE_PATH")
+
+if [ "$STATE" != "ready_for_judge" ] || [ -z "$TASK_ID" ]; then
+  exit 0
+fi
+
+# Prevent double-invocation for the same task+phase+round
+MARKER="/tmp/.judge-invoked-${TASK_ID}-${PHASE}-round-${ROUND}"
+if [ -f "$MARKER" ]; then
+  exit 0
+fi
+touch "$MARKER"
+
+# Find the Codex CLI binary (bundled with VS Code extension)
+CODEX_BIN="${CODEX_CLI:-}"
+if [ -z "$CODEX_BIN" ]; then
+  CODEX_BIN=$(ls -t ~/.vscode/extensions/openai.chatgpt-*/bin/*/codex 2>/dev/null | head -1)
+fi
+
+if [ -z "$CODEX_BIN" ] || [ ! -x "$CODEX_BIN" ]; then
+  echo "WARNING: Codex CLI not found. Set CODEX_CLI env var or install the Codex VS Code extension." >&2
+  rm -f "$MARKER"
+  exit 0
+fi
+
+# Determine the repo root (parent of agent-loop/)
+REPO_ROOT=$(echo "$FILE_PATH" | sed 's|/agent-loop/.*||')
+
+# Log file for this invocation
+LOG_FILE="/tmp/codex-judge-${TASK_ID}-${PHASE}-round-${ROUND}.log"
+
+# --- Immediate feedback to Claude Code ---
+CODEX_VERSION=$("$CODEX_BIN" --version 2>/dev/null || echo "unknown")
+echo ""
+echo "=== AUTO-JUDGE HOOK FIRED ==="
+echo "  Task:    $TASK_ID"
+echo "  Phase:   $PHASE"
+echo "  Round:   $ROUND"
+echo "  Model:   gpt-5.4 (xhigh reasoning)"
+echo "  Codex:   $CODEX_VERSION"
+echo "  Log:     $LOG_FILE"
+echo "  Monitor: tail -f $LOG_FILE"
+echo "============================="
+echo ""
+
+# macOS notification: judge dispatched
+osascript -e "display notification \"Dispatching judge: $PHASE round $ROUND\" with title \"$TASK_ID\" sound name \"Submarine\"" 2>/dev/null || true
+
+# Launch codex exec fully detached from this process tree.
+# Claude Code's hook runner waits for all child processes — a simple `&`
+# still blocks because the subshell remains a child. Using nohup + redirects
+# + disown ensures the hook exits instantly while Codex runs independently.
+WRAPPER="/tmp/.judge-run-${TASK_ID}-${PHASE}-round-${ROUND}.sh"
+cat > "$WRAPPER" <<SCRIPT
+#!/bin/bash
+START_TIME=\$(date +%s)
+echo "[\$(date -Iseconds)] Invoking Codex judge for task=$TASK_ID phase=$PHASE round=$ROUND" > "$LOG_FILE"
+echo "[dispatch] model=gpt-5.4 reasoning=xhigh codex=$CODEX_VERSION" >> "$LOG_FILE"
+echo "[dispatch] repo=$REPO_ROOT" >> "$LOG_FILE"
+echo "" >> "$LOG_FILE"
+
+"$CODEX_BIN" exec \\
+  --full-auto \\
+  -m gpt-5.4 \\
+  -c 'model_reasoning_effort="xhigh"' \\
+  -C "$REPO_ROOT" \\
+  "judge $TASK_ID" \\
+  >> "$LOG_FILE" 2>&1
+
+EXIT_CODE=\$?
+END_TIME=\$(date +%s)
+ELAPSED=\$(( END_TIME - START_TIME ))
+ELAPSED_MIN=\$(( ELAPSED / 60 ))
+ELAPSED_SEC=\$(( ELAPSED % 60 ))
+
+VERDICT=\$(jq -r '.verdict // "unknown"' "$FILE_PATH" 2>/dev/null || echo "unknown")
+NEW_STATE=\$(jq -r '.state // "unknown"' "$FILE_PATH" 2>/dev/null || echo "unknown")
+NEW_ROUND=\$(jq -r '.round // "?"' "$FILE_PATH" 2>/dev/null || echo "?")
+
+echo "" >> "$LOG_FILE"
+echo "============================================" >> "$LOG_FILE"
+echo "[\$(date -Iseconds)] JUDGE COMPLETE" >> "$LOG_FILE"
+echo "  Task:     $TASK_ID" >> "$LOG_FILE"
+echo "  Phase:    $PHASE" >> "$LOG_FILE"
+echo "  Round:    $ROUND" >> "$LOG_FILE"
+echo "  Verdict:  \$VERDICT" >> "$LOG_FILE"
+echo "  State:    \$NEW_STATE" >> "$LOG_FILE"
+echo "  Exit:     \$EXIT_CODE" >> "$LOG_FILE"
+echo "  Duration: \${ELAPSED_MIN}m \${ELAPSED_SEC}s" >> "$LOG_FILE"
+echo "============================================" >> "$LOG_FILE"
+
+# Count findings if judge.md was updated
+JUDGE_FILE="$REPO_ROOT/agent-loop/$TASK_ID/judge.md"
+BLOCKERS=""
+HIGHS=""
+MEDIUMS=""
+LOWS=""
+if [ -f "\$JUDGE_FILE" ]; then
+  BLOCKERS=\$(grep -c '^- B-' "\$JUDGE_FILE" 2>/dev/null || echo "0")
+  HIGHS=\$(grep -c '^- H-' "\$JUDGE_FILE" 2>/dev/null || echo "0")
+  MEDIUMS=\$(grep -c '^- M-' "\$JUDGE_FILE" 2>/dev/null || echo "0")
+  LOWS=\$(grep -c '^- L-' "\$JUDGE_FILE" 2>/dev/null || echo "0")
+fi
+
+# macOS notification with verdict and details
+if [ "\$VERDICT" = "accepted" ]; then
+  SOUND="Glass"
+  DETAIL="Phase accepted! (\${ELAPSED_MIN}m \${ELAPSED_SEC}s)"
+elif [ "\$VERDICT" = "needs_revision" ]; then
+  SOUND="Basso"
+  DETAIL="B:\$BLOCKERS H:\$HIGHS M:\$MEDIUMS L:\$LOWS (\${ELAPSED_MIN}m \${ELAPSED_SEC}s)"
+elif [ "\$VERDICT" = "escalated" ]; then
+  SOUND="Sosumi"
+  DETAIL="Escalated to coordinator (\${ELAPSED_MIN}m \${ELAPSED_SEC}s)"
+else
+  SOUND="Ping"
+  DETAIL="exit=\$EXIT_CODE (\${ELAPSED_MIN}m \${ELAPSED_SEC}s)"
+fi
+
+osascript -e "display notification \"\$DETAIL\" with title \"Judge: $TASK_ID\" subtitle \"$PHASE r$ROUND → \$VERDICT\" sound name \"\$SOUND\"" 2>/dev/null || true
+
+rm -f "$WRAPPER"
+SCRIPT
+chmod +x "$WRAPPER"
+
+nohup "$WRAPPER" </dev/null >/dev/null 2>&1 &
+disown
+
+exit 0

--- a/.claude/hooks/auto-judge.sh
+++ b/.claude/hooks/auto-judge.sh
@@ -10,6 +10,10 @@
 
 set -euo pipefail
 
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
 INPUT=$(cat)
 
 # Get the file path from tool input

--- a/.claude/hooks/post-pr-review.sh
+++ b/.claude/hooks/post-pr-review.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Hook: After the /pr-review-toolkit:review-pr skill runs, create a marker
+# file so the pre-pr-review hook stops blocking PR creation / git push.
+#
+# This fires on PostToolUse for the Skill tool. It checks if the skill
+# invoked was "pr-review-toolkit:review-pr" or "review-pr".
+
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_INPUT=$(echo "$INPUT" | jq -r '.tool_input // empty')
+
+# Check if this was a Skill tool call for pr-review-toolkit:review-pr
+SKILL_NAME=$(echo "$INPUT" | jq -r '.tool_input.skill // empty')
+
+if [ -z "$SKILL_NAME" ]; then
+  exit 0
+fi
+
+# Match the review-pr skill (with or without namespace prefix)
+if [ "$SKILL_NAME" = "pr-review-toolkit:review-pr" ] || [ "$SKILL_NAME" = "review-pr" ]; then
+  # Get current branch to create the marker
+  CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+  if [ -n "$CWD" ]; then
+    BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  else
+    BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  fi
+
+  SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '_')
+  MARKER="/tmp/.pr-review-done-${SAFE_BRANCH}"
+  touch "$MARKER"
+fi
+
+exit 0

--- a/.claude/hooks/post-pr-review.sh
+++ b/.claude/hooks/post-pr-review.sh
@@ -7,6 +7,10 @@
 
 set -euo pipefail
 
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
 INPUT=$(cat)
 TOOL_INPUT=$(echo "$INPUT" | jq -r '.tool_input // empty')
 

--- a/.claude/hooks/pre-pr-review.sh
+++ b/.claude/hooks/pre-pr-review.sh
@@ -15,6 +15,10 @@
 
 set -euo pipefail
 
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 

--- a/.claude/hooks/pre-pr-review.sh
+++ b/.claude/hooks/pre-pr-review.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Hook: Block PR creation and pushes to PR branches until /pr-review-toolkit:review-pr has been run.
+#
+# Intercepts:
+#   - gh pr create
+#   - git push (when on a non-main/master branch, i.e. likely a PR branch)
+#
+# How it works:
+#   - Reads the tool_input.command from stdin JSON
+#   - If it matches a PR-related command, blocks with exit 2 and a message
+#     instructing Claude to run the review skill first
+#   - A marker file (/tmp/.pr-review-done-<branch>) is created by the
+#     companion post-review hook after the skill runs, so the block
+#     only fires once per branch per session.
+
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Exit early if no command (not a Bash tool call with a command)
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Detect PR creation
+IS_PR_CREATE=false
+if echo "$COMMAND" | grep -qE 'gh\s+pr\s+create'; then
+  IS_PR_CREATE=true
+fi
+
+# Detect git push (to a non-main branch — likely a PR branch)
+IS_GIT_PUSH=false
+if echo "$COMMAND" | grep -qE 'git\s+push'; then
+  IS_GIT_PUSH=true
+fi
+
+# If neither, allow
+if [ "$IS_PR_CREATE" = false ] && [ "$IS_GIT_PUSH" = false ]; then
+  exit 0
+fi
+
+# Check for the current branch to build a marker file path
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+if [ -n "$CWD" ]; then
+  BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+else
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+fi
+
+# For git push: skip if pushing to main/master (not a PR workflow)
+if [ "$IS_GIT_PUSH" = true ]; then
+  if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+    exit 0
+  fi
+fi
+
+# Check if review was already done for this branch (marker file exists)
+SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '_')
+MARKER="/tmp/.pr-review-done-${SAFE_BRANCH}"
+
+if [ -f "$MARKER" ]; then
+  exit 0
+fi
+
+# Block the action and instruct Claude to run the review skill first
+if [ "$IS_PR_CREATE" = true ]; then
+  echo "BLOCKED: You must run /pr-review-toolkit:review-pr before creating a PR. After the review completes, retry this command." >&2
+else
+  echo "BLOCKED: You must run /pr-review-toolkit:review-pr before pushing to PR branch '$BRANCH'. After the review completes, retry this command." >&2
+fi
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,5 +3,47 @@
     "superpowers@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
     "github@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-pr-review.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-pr-review.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/auto-judge.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/auto-judge.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -124,7 +124,7 @@ gh api graphql \
   -F owner="$OWNER" -F name="$REPO" -F pr=$PR_NUMBER \
   -f query="$(cat /tmp/pr-threads.graphql)" > /tmp/pr-threads-raw.json
 
-# Parse: filter to unresolved+not-outdated, extract key fields, group by source
+# Parse: filter to unresolved (including outdated — GitHub UI still shows them), extract key fields, group by source
 python3 -c "
 import json, sys
 
@@ -143,9 +143,10 @@ unresolved = [
         'author': t['comments']['nodes'][0]['author']['login'] if t['comments']['nodes'] else 'unknown',
         'body': t['comments']['nodes'][0]['body'] if t['comments']['nodes'] else '',
         'comment_count': len(t['comments']['nodes']),
+        'is_outdated': t['isOutdated'],
     }
     for t in threads
-    if not t['isResolved'] and not t['isOutdated']
+    if not t['isResolved']
 ]
 
 # Classify source
@@ -174,6 +175,12 @@ print(json.dumps(result, indent=2))
 merge results. Repeat until all pages are fetched.
 
 Read `/tmp/pr-threads-parsed.json` to get the clean, filtered thread list.
+
+> **IMPORTANT — Include outdated threads:** Do NOT filter out `isOutdated` threads.
+> GitHub's UI still displays outdated unresolved threads, and they must be resolved
+> to clear the PR. The `is_outdated` field is included in the output so you can
+> note it when processing, but never skip a thread just because it's outdated.
+
 Only the `body` of the **first comment** in each thread is extracted (the original finding) —
 this keeps output small. If you need follow-up comments in a thread, fetch them individually
 when processing that specific thread in Step 3.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Copilot CLI globally
-RUN npm install -g @github/copilot
+RUN npm install -g @github/copilot && npm cache clean --force
 
 RUN mkdir -p /data && chmod 700 /data
 
@@ -23,6 +23,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY server/ server/
 COPY tests/ tests/
 COPY pyproject.toml .
+
+RUN useradd --create-home --shell /bin/bash --uid 1000 appuser && \
+    chown -R appuser:appuser /data /app
+USER appuser
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && \
 # Install Copilot CLI globally
 RUN npm install -g @github/copilot
 
+RUN mkdir -p /data && chmod 700 /data
+
 WORKDIR /app
 
 # Install Python dependencies

--- a/agent-loop/002-credential-setup/builder-archive.md
+++ b/agent-loop/002-credential-setup/builder-archive.md
@@ -1,0 +1,458 @@
+# Builder Archive — 002-credential-setup
+
+## Phase Summaries
+<!-- Agents read this section every round -->
+
+### [specify] Phase Summary (rounds 1-5, accepted via coordinator at round 6)
+
+#### Key Decisions
+- D-1: Credential status page at `/` owned by this spec, not dependent on spec 003's dashboard
+- D-2: Status page shows source + masked token only — no connection status claims (Peter's decision)
+- D-3: MCP credential freshness boundary: resolved at process startup, rotation effective on next `docker exec` connection, active sessions keep their token
+- D-4: 4 distinct token validation failure modes: format error, auth error, permission error, SDK error
+- D-5: Fernet key loss → treat as no stored credential, require re-entry via setup wizard
+
+#### Findings Resolved
+- H-1 (R1): MCP freshness gap → FR-010 added with explicit per-connection resolution
+- H-2 (R1): Expired token under-specified → FR-005 restructured with 4 failure modes
+- H-3 (R1): Dashboard dependency on spec 003 → FR-009 added, credential status page owned by this spec
+- B-1 (R2): Task.md AC edits without coordinator → Peter approved all changes
+- M-1 (R2): SDK-unavailable missing from US1 → AS6 added
+- M-2 (R2): FR-009 "connection status" contradicts no-revalidation → removed, Peter chose source+token only
+- H-1 (R3): US1 narrative still said "confirming connection" → updated to match FR-009
+- L-1 (R3): Stale requirements checklist → updated FR-005, SC-002, added FR-009/FR-010
+- L-1 (R4): builder.md archival rule violation → builder-archive.md created, rounds archived
+
+#### Artifacts Produced
+- `specs/002-credential-setup/spec.md` — 10 FRs, 3 user stories, 5 edge cases, 5 success criteria
+- `specs/002-credential-setup/checklists/requirements.md` — quality checklist
+- `agent-loop/002-credential-setup/task.md` — 9 acceptance criteria
+
+#### Deferred / Out of Scope
+- Copilot SDK error type distinction (auth vs permission) — flagged for design-phase spike
+- Dashboard UI (spec 003)
+- External KMS / Vault integration
+
+### [design] Phase Summary (rounds 1-8, accepted at round 8)
+
+#### Key Decisions
+- D-1: Two-step validation: GET /user (stdlib urllib) → list_models() for 4 distinct error types (format, auth, permission, sdk)
+- D-2: `_probe_github_auth()` returns `bool | None` — diagnostic probe, not gate. Only 401 maps to auth; other non-2xx is inconclusive
+- D-3: Confidence model: 401→auth(high), 2xx+Copilot fail→permission(high), inconclusive→auth fallback(low)
+- D-4: Permission error broadened from "missing copilot_requests" to "cannot access Copilot" (coordinator Option A, round 5)
+- D-5: All 4 error types carry verbose multi-line messages with specific URLs and remediation steps
+- D-6: No new HTTP dependencies — `urllib.request` (stdlib) for GET /user, `asyncio.to_thread` for async wrapper
+- D-7: Flash messages via query params, PRG pattern for forms (R-5 YAGNI)
+- D-8: 4 new modules: credential_store, credential_resolver, token_validator, web_routes (flat layout in server/)
+- D-9: Temporary client pattern for validation — TokenValidator creates/stops CopilotReviewClient per validate()
+- D-10: MCP no-credential error via existing `_startup_error` mechanism on CopilotReviewClient
+
+#### Findings Resolved
+- B-1 (R1): Design needed 4 distinct error types → restructured with two-step validation approach
+- H-1 (R1): MCP no-credential error contract → defined via existing _startup_error pattern in copilot_client.py
+- B-1 (R2, AP-002): Token classification redesigned — two-step validation with confidence model
+- M-1 (R3, AP-002): validate_copilot_access type signature → corrected to accept `bool | None`
+- B-1 (R3, AP-002): Confidence model tightened — only 401 = auth, GET /user 403 = inconclusive
+- L-1 (R3): Builder archival non-compliant → design round 1 archived
+- B-1 (R4): Escalated — SDK cannot distinguish copilot_requests from other Copilot access failures
+- B-1 (R5): Coordinator Option A applied — all error messages verbose with URLs across all artifacts
+- B-1 (R6, AP-002): Format and SDK paths missing verbose messages → propagated to all error paths, wording aligned
+- L-1 (R6): Archived design rounds 2-3
+- B-1 (R7, AP-002): SDK error path missing URL → added docs.github.com/en/copilot
+- L-1 (R7): Builder archival regression (4 active rounds) → round 4 archived in R8
+
+#### Artifacts Produced
+- `specs/002-credential-setup/research.md` — 5 research decisions (R-1 through R-5)
+- `specs/002-credential-setup/data-model.md` — StoredCredential, CredentialSource, ResolvedCredential, TokenValidationError, NoCredentialError
+- `specs/002-credential-setup/contracts/credential-store.md` — Fernet encrypt/decrypt, file I/O, atomic writes
+- `specs/002-credential-setup/contracts/credential-resolver.md` — Docker secret > env var > stored resolution
+- `specs/002-credential-setup/contracts/token-validator.md` — format → GitHub auth probe → Copilot access, verbose error messages
+- `specs/002-credential-setup/contracts/web-routes.md` — GET /, GET /setup, POST /setup, GET /settings, POST /settings/rotate
+- `specs/002-credential-setup/plan.md` — technical context, constitution check, project structure, integration points
+
+#### Deferred / Out of Scope
+- None
+
+---
+
+## Raw Archived Rounds
+<!-- Agents read this section only when tracing specific findings or decisions -->
+
+### [specify] Round 1 — builder
+
+#### Summary
+
+- Reviewed existing draft spec against web research on Fernet encryption, Docker secrets, and GitHub PAT formats
+- Tightened all 8 functional requirements with specific, testable criteria
+- Answered all 3 open edge case questions with concrete behaviors
+- Added 2 new edge cases (SDK unavailable during validation, Docker secret trailing whitespace)
+- Added new acceptance scenarios (US1-AS4: Copilot permission failure, US1-AS5: env var bypass, US2-AS4: externally managed credential display, US3-AS4: no credential available)
+- Added SC-005 for invalid token error message quality
+- Added Fernet Key as a third key entity
+- Created requirements quality checklist
+
+#### Speckit Artifacts
+
+- `specs/002-credential-setup/spec.md` — updated (was 91 lines, now ~115 lines)
+- `specs/002-credential-setup/checklists/requirements.md` — created
+- `agent-loop/002-credential-setup/task.md` — created
+- `agent-loop/002-credential-setup/status.json` — created
+
+#### Design / Implementation Notes
+
+Key refinements to the draft spec:
+
+1. **FR-001 expanded**: Added Fernet key lifecycle — auto-generated on first use, persisted in volume, key loss invalidates stored credentials. This was implicit but needed to be explicit for testability.
+
+2. **FR-003 tightened**: Enumerated all rejected prefixes (`ghp_`, `gho_`, `ghs_`, `ghu_`) instead of just "classic PATs." Research confirmed these are the standard GitHub token prefixes. Error messages must identify the specific rejected type.
+
+3. **FR-005 strengthened**: Added the case where the Copilot SDK itself is unavailable (not just auth failure). The token must not be stored if validation cannot complete.
+
+4. **FR-006 expanded**: Specified masking format (`github_pat_...XXXX`), and added the behavior when credential is externally managed (Docker secret/env var) — rotation form is disabled with explanation.
+
+5. **Edge cases answered**:
+   - Key deleted → treat as no credential, fallback or setup wizard
+   - Invalid stored credential → detected on first MCP use, not at startup
+   - Shared volume → unsupported, atomic writes for corruption mitigation
+   - SDK unavailable → format validation passes but Copilot validation fails with specific error
+   - Docker secret whitespace → strip before use
+
+6. **Architecture insight**: MCP and web are separate processes (`docker exec` vs uvicorn). This means hot-reload is a non-issue — each MCP invocation reads fresh credentials. This simplifies the design significantly vs cross-process coordination.
+
+#### Verification
+
+- **Checked**: [Fernet docs at cryptography.io](https://cryptography.io/en/latest/fernet/) — confirmed Fernet.generate_key() produces 44-char URL-safe base64 key, AES-128-CBC + HMAC-SHA256
+- **Checked**: [Docker Compose secrets docs](https://docs.docker.com/compose/how-tos/use-secrets/) — confirmed non-Swarm secrets are file mounts at `/run/secrets/<name>`, no Docker-level encryption
+- **Checked**: [GitHub token prefixes gist](https://gist.github.com/magnetikonline/073afe7909ffdd6f10ef06a00bc3bc88) — confirmed `github_pat_` for fine-grained, `ghp_` for classic, `gho_`/`ghs_`/`ghu_` for app tokens
+- **Checked**: [GitHub blog on fine-grained PATs](https://github.blog/security/application-security/introducing-fine-grained-personal-access-tokens-for-github/) — confirmed 93-char length, fine-grained permissions model
+- **Corrections**: None — research validated the existing spec's technical claims. Additions were refinements, not corrections.
+
+#### Remaining Risks
+
+- Copilot SDK `list_models()` is Technical Preview — API may change. Mitigation: assumption documented, fallback path to be designed in design phase.
+- Docker Compose secrets without Swarm have no Docker-level encryption. Mitigation: Fernet layer provides at-rest encryption independently.
+- FR-001 names Fernet specifically — this is a constitution constraint, not a spec leak. If the judge flags this, the response is that the constitution mandates "Fernet encryption in Docker named volume."
+
+### [specify] Round 2 — builder
+
+#### Summary
+
+- Addressed all 3 judge findings (H-1, H-2, H-3) from round 1
+- Added FR-009 (credential status page) and FR-010 (MCP freshness boundary)
+- Separated token validation errors into 4 distinct failure modes in FR-005
+- Replaced all "dashboard" references with "credential status page"
+- Updated task.md ACs to match spec changes
+- Cross-document consistency verified (AP-002, AP-005 check)
+
+#### Changes Since Last Round
+
+- `specs/002-credential-setup/spec.md`:
+  - All "dashboard" references → "credential status page" (H-3)
+  - US1-AS3 split into AS3 (format error), AS4 (auth error), AS5 (permission error) — distinct failure modes (H-2)
+  - US1-AS5 (old) renumbered to AS6, expanded to cover both env var and Docker secret
+  - FR-005 restructured with 4 explicit failure modes: format, auth, permission, SDK (H-2)
+  - FR-009 added: credential status page at `/`, owned by this spec, post-setup destination (H-3)
+  - FR-010 added: MCP credential freshness boundary — resolved at process startup, rotation takes effect on next connection, long-lived sessions keep their token (H-1)
+  - SC-002 updated: clarified "next MCP connection" and "active sessions continue with original token" (H-1)
+- `agent-loop/002-credential-setup/task.md`:
+  - AC-2: "redirects to dashboard" → "redirects to credential status page"
+  - AC-3: expanded to list all 4 error types
+  - AC-4: added Docker secret alongside env var
+  - AC-5: clarified "next MCP connection uses new token"
+
+#### Responses to Judge Findings
+
+- **H-1** (MCP credential freshness): Addressed by adding FR-010, which makes the freshness boundary explicit. Credential resolution occurs at MCP process startup. Each `docker exec` starts a fresh process. Long-lived sessions bind to their startup token — this is documented as expected behavior, analogous to env var binding at process start. SC-002 updated to match.
+
+- **H-2** (Expired token error path under-specified): Addressed by restructuring FR-005 into 4 distinct failure modes (format, auth, permission, SDK). US1 acceptance scenarios now have separate scenarios for each: AS3 (format error — wrong prefix/empty), AS4 (auth error — expired/revoked), AS5 (permission error — missing copilot_requests). The previous FR-005 wording that hardcoded "works for GitHub but not for Copilot" for all failures is replaced with per-mode messages.
+
+- **H-3** (Post-setup destination depends on spec 003): Addressed by adding FR-009, which defines a credential status page at `/` owned by this spec. All "dashboard" references replaced with "credential status page." FR-009 explicitly states this spec MUST NOT depend on spec 003 for the post-setup experience. Spec 003 may later expand or replace this page.
+
+#### Verification
+
+- **Checked**: Grep for "dashboard" in spec.md — 0 matches. All references replaced.
+- **Checked**: Cross-document consistency (AP-002): task.md ACs match spec acceptance scenarios. FR-010's freshness boundary matches SC-002's wording. FR-005's error taxonomy matches US1 acceptance scenarios AS3-AS5.
+- **Checked**: Scope creep (AP-003): FR-009 defines a minimal credential status page, not a full dashboard. It explicitly states spec 003 may expand it. The page shows only credential-owned information (source, masked token, connection status).
+- **Checked**: Incremental fix consistency (AP-005): Re-read entire spec after changes. No new contradictions introduced. US2 acceptance scenarios still consistent (rotation path uses same error taxonomy from FR-005).
+- **Corrections**: None needed after consistency check.
+
+#### Remaining Risks
+
+- Copilot SDK `list_models()` is Technical Preview — API may change. Mitigation: assumption documented, fallback path to be designed in design phase.
+- Distinguishing "auth error" (expired/revoked) from "permission error" (missing copilot_requests) depends on the Copilot SDK surfacing distinct exception types. If the SDK returns a generic error for both, the design phase must define a fallback classification strategy. Flagged for design-phase spike.
+
+### [specify] Round 3 — builder
+
+(Escalation resolved: Peter approved task.md AC changes and chose "source + masked token only" for status page. Added SDK-unavailable AS6 to US1. Tightened FR-009 to prohibit connection status claims.)
+
+### [specify] Round 4 — builder
+
+(Fixed stale US1 narrative contradicting FR-009. Updated requirements checklist for FR-005/SC-002/FR-009/FR-010.)
+
+### [specify] Round 5 — builder
+
+(Context management: created builder-archive.md, archived rounds 1-2. No spec changes.)
+
+## [design] Archived Rounds
+
+### [design] Round 1 — builder
+
+#### Summary
+
+- Completed Phase 0 (Research) and Phase 1 (Design & Contracts)
+- Created research.md with 5 research decisions including Copilot SDK error classification spike (R-4)
+- Created data-model.md with 4 entities: StoredCredential, CredentialSource, ResolvedCredential, TokenValidationError
+- Created 4 contract files: credential-store, credential-resolver, token-validator, web-routes
+- Created plan.md with technical context, constitution check, project structure, and integration points
+- R-4 spike resolved: SDK cannot distinguish auth vs permission errors — combined into single "auth" error_type
+
+#### Speckit Artifacts
+
+- `specs/002-credential-setup/research.md` — 5 research decisions (R-1 through R-5)
+- `specs/002-credential-setup/data-model.md` — entities, file layout, relationships
+- `specs/002-credential-setup/plan.md` — technical context, constitution check, project structure
+- `specs/002-credential-setup/contracts/credential-store.md` — Fernet encrypt/decrypt interface
+- `specs/002-credential-setup/contracts/credential-resolver.md` — multi-source resolution interface
+- `specs/002-credential-setup/contracts/token-validator.md` — format + Copilot validation interface
+- `specs/002-credential-setup/contracts/web-routes.md` — FastAPI routes for setup/settings/status
+
+#### Design / Implementation Notes
+
+1. SDK error classification uses string matching, no structured error codes
+2. 4 new modules: credential_store, credential_resolver, token_validator, web_routes
+3. Temporary client pattern for validation
+4. Flash messages via query params (YAGNI)
+5. Integration: mcp_server.py uses CredentialResolver, main.py gains templates/routes, copilot_client.py unchanged
+6. Docker: named volume, localhost binding, /data/ directory
+
+#### Verification
+
+- Confirmed copilot_client.py error classification, mcp_server.py token reading, main.py minimal state, docker-compose.yml bindings, Dockerfile structure, constitution compliance
+- Corrections: None
+
+#### Remaining Risks
+
+- Copilot SDK Technical Preview, cryptography OpenSSL requirement
+
+### [design] Round 2 — builder
+
+#### Summary
+
+- Addressed B-1 (AP-002): Redesigned token validation to produce 4 distinct error types matching FR-005
+- Addressed H-1: Designed explicit MCP no-credential error contract
+- Updated 4 design artifacts: research.md, data-model.md, token-validator.md, plan.md
+- Cross-document consistency verified across all 7 design artifacts
+
+#### Speckit Artifacts
+
+- `specs/002-credential-setup/research.md` — R-4 rewritten: two-step validation approach (GitHub API + Copilot SDK)
+- `specs/002-credential-setup/data-model.md` — TokenValidationError now has 4 error_type values; added NoCredentialError entity
+- `specs/002-credential-setup/contracts/token-validator.md` — rewritten: 3-step validate() sequence (format → github_auth → copilot_access)
+- `specs/002-credential-setup/plan.md` — MCP integration section expanded with no-credential error contract
+
+#### Design / Implementation Notes
+
+1. Two-step validation: GET /user (stdlib urllib) → list_models(). 4 distinct error paths.
+2. No new dependencies. MCP no-credential contract via existing _startup_error pattern.
+3. copilot_client.py remains unchanged.
+
+#### Verification
+
+- Confirmed GET /user behavior, Copilot 403 multi-mode, stdlib urllib, cross-doc consistency
+- Corrections: None
+
+#### Remaining Risks
+
+- Copilot SDK Technical Preview, GitHub API rate limiting, cryptography OpenSSL
+
+### [design] Round 3 — builder
+
+#### Summary
+
+- Addressed B-1 (AP-002): Tightened classification with confidence model
+- Only HTTP 401 → "auth"; confirmed-auth + Copilot fail → "permission"; inconclusive fallback
+- Permission message broadened to cover copilot_requests, subscription, and policy
+- Renamed validate_github_auth() → _probe_github_auth() (diagnostic, not gate)
+
+#### Speckit Artifacts
+
+- `specs/002-credential-setup/research.md` — R-4 tightened: confidence model table
+- `specs/002-credential-setup/data-model.md` — error_type descriptions tightened
+- `specs/002-credential-setup/contracts/token-validator.md` — rewritten with bool | None return
+
+#### Design / Implementation Notes
+
+1. Confidence model: 401 = auth (high), 2xx + Copilot fail = permission (high), inconclusive = auth fallback (low)
+2. Probe, not gate: _probe_github_auth() returns bool | None, doesn't block on non-401
+3. GET /user 403 treated as inconclusive, not auth failure
+
+#### Verification
+
+- Confirmed GitHub API 401/403 semantics, cross-document confidence model consistency
+- Corrections: None
+
+#### Remaining Risks
+
+- Copilot SDK Technical Preview, GitHub API rate limiting, cryptography OpenSSL
+
+### [design] Round 4 — builder
+
+#### Summary
+
+- Fixed M-1: validate_copilot_access() type signature corrected to bool | None
+- Fixed L-1: Archived design round 1 to builder-archive.md
+- Escalated B-1 to coordinator: SDK cannot distinguish copilot_requests from other Copilot access failures. Presented 3 options; recommended Option A (broaden FR-005).
+
+#### Design / Implementation Notes
+
+1. Coordinator decided Option A — broaden FR-005 permission error from "missing copilot_requests" to "cannot access Copilot"
+2. Type signature alignment: _probe_github_auth() → bool | None, validate_copilot_access() accepts bool | None
+
+#### Verification
+
+- Confirmed type signature consistency, builder archival compliance, AP-007 correct escalation pattern
+- Corrections: None
+
+#### Remaining Risks
+
+- Pending coordinator decision on FR-005 scope (resolved in round 5 via Option A)
+
+### [design] Round 5 — builder
+
+(Coordinator resolved escalation: Option A — broaden FR-005 permission error + verbose messages with URLs. Applied across all design artifacts: spec.md, task.md, token-validator.md, research.md, data-model.md, checklists/requirements.md.)
+
+### [design] Round 6 — builder
+
+(Propagated verbose message requirement to format and SDK error paths. Aligned wording: "URLs and remediation steps" consistently. Archived design rounds 2-3.)
+
+### [design] Round 7 — builder
+
+(Added docs.github.com/en/copilot URL to SDK error messages. All 4 error types now carry at least one troubleshooting URL.)
+
+### [design] Round 8 — builder
+
+(Archived design round 4 from builder.md. Context management fix only — no artifact changes.)
+
+### [plan] Round 1 — builder
+
+Generated `specs/002-credential-setup/tasks.md` with 26 tasks across 6 phases (Setup, Foundational, US1 MVP, US2, US3, Polish). TDD RED-GREEN pairs for all modules. 100% FR/AC/edge-case coverage. Phase-compacted builder.md (design rounds archived).
+
+### [plan] Round 2 — builder
+
+Addressed R1 findings: M-1 (Phase 5 dependency contradiction — fixed to depend on Phase 3, not Phase 2), M-2 (missing RED task for MCP credential boundary — inserted T017 for MCP integration tests, renumbered T017-T026 → T018-T027, 27 tasks total). AC-5 gap closed (T017 tests rotation pickup on next MCP connection).
+
+### [plan] Round 3 — builder
+
+Addressed M-1 (AP-002): Unified error contract across `plan.md`, `data-model.md`, and `tasks.md` — all now use `NoCredentialError(CopilotError)` instead of mixed `CopilotUnavailableError`/standalone-`NoCredentialError`. T018 updated to include creating the `NoCredentialError` class in `copilot_client.py`.
+
+### [plan] Round 4 — builder
+
+Addressed M-1 (AP-002): Updated `plan.md` project structure and integration note — `copilot_client.py` now marked as MODIFIED (was UNCHANGED), integration note describes the minimal modification (add `NoCredentialError` class). Archived plan rounds 1-2.
+
+### [plan] Round 5 — builder
+
+Addressed M-1 (AP-002): Defined MCP error-mapping contract for `NoCredentialError` → `{"error": "no_credential", ...}`. Added handler contract to plan.md, RED coverage in T017, GREEN implementation in T018. Initially scoped to all 4 MCP tools (later narrowed in round 6).
+
+### [plan] Round 6 — builder
+
+Addressed M-1 (AP-002): Fixed T022 — changed "Verify MCP returns NoCredentialError" to "Verify MCP `start_review` returns `{"error": "no_credential", ...}` response payload". Addressed M-2 (AP-002): Narrowed handler requirement from "all 4 MCP tools" to "`start_review` and `discuss`" only — read-only tools only access session store. Updated plan.md, tasks.md, data-model.md.
+
+### [plan] Round 7 — builder
+
+Addressed M-1 (AP-002): Narrowed `NoCredentialError` handler from `start_review` + `discuss` to `start_review` only. `discuss` never checks `_startup_error` — its path is `send_followup()` → `send_review()` on existing sessions. Updated plan.md, tasks.md (T017/T018), data-model.md.
+
+### [plan] Round 8 — builder
+
+Addressed M-1 (AP-002): Narrowed T022 to resolver-only source-priority assertions. Removed web UI redirect and MCP error assertions (already owned by T011/T017). Updated Phase 5 dependency from Phase 3 → Phase 2. Updated parallel opportunities to include Phase 3.
+
+### [plan] Round 9 — builder
+
+Addressed M-1 (AP-005): Fixed Phase 6 dependency to include Phase 5. Phase 6 previously said "Depends on Phase 4 completion" but Phase 5 runs in parallel with Phase 3/4, so T027 could start before US3 source-priority work is complete. Fixed to "Depends on Phase 4 and Phase 5 completion."
+
+### [plan] Round 10 — builder
+
+Addressed M-1: Expanded T010 RED coverage to require verbose message content and URL assertions for all 4 error types (format, auth, permission, sdk), not just format. Added closing sentence binding all 4 types to accepted templates in contracts/token-validator.md (AC-3).
+
+### [plan] Phase Summary (rounds 1-10, accepted)
+
+#### Key Decisions
+- D-1: 27 tasks across 6 phases (Setup, Foundational, US1 MVP, US2, US3, Polish)
+- D-2: TDD RED-GREEN pairs for all modules — no implementation without failing test first
+- D-3: Phase 5 can run in parallel with Phase 3 and Phase 4 (depends only on Phase 2)
+- D-4: Phase 6 depends on both Phase 4 and Phase 5 completion
+- D-5: NoCredentialError handler required only in start_review MCP tool (not discuss or read-only tools)
+- D-6: T022 narrowed to resolver-only source-priority assertions (web/MCP coverage already in T011/T017)
+- D-7: All 4 error types (format, auth, permission, sdk) must assert verbose message content and URLs in RED tests
+
+#### Findings Resolved
+- M-1 (R1): Phase 5 dependency → fixed to Phase 2 (not Phase 3)
+- M-2 (R1): Missing MCP credential boundary tests → T017 inserted
+- M-1 (R3, AP-002): Unified NoCredentialError(CopilotError) across plan.md, data-model.md, tasks.md
+- M-1 (R4, AP-002): copilot_client.py marked as MODIFIED in plan.md
+- M-1 (R5, AP-002): MCP error-mapping contract for NoCredentialError defined
+- M-1 (R6, AP-002): T022 fixed to assert response payload, handler narrowed to start_review+discuss
+- M-1 (R7, AP-002): Handler narrowed to start_review only (discuss never checks _startup_error)
+- M-1 (R8, AP-002): T022 narrowed to resolver-only assertions
+- M-1 (R9, AP-005): Phase 6 dependency fixed to include Phase 5
+- M-1 (R10): T010 RED coverage expanded for all 4 error types' verbose messages
+
+#### Artifacts Produced
+- `specs/002-credential-setup/tasks.md` — 27 tasks, 6 phases, TDD RED-GREEN pairs
+
+#### Deferred / Out of Scope
+- None
+
+### [build] Phase Summary (rounds 1-2, accepted at round 2)
+
+#### Key Decisions
+- D-1: Implemented all 27 tasks (T001-T027) across 6 phases with TDD
+- D-2: Exception catch in credential_store.py narrowed from `(InvalidToken, Exception)` to `(InvalidToken, ValueError)` per contract
+- D-3: mask_token() derives prefix from actual token string, not hardcoded `github_pat_`
+- D-4: Security audit fixed `ResolvedCredential.__repr__` to mask token value
+
+#### Findings Resolved
+- H-1 (R1): credential_store.py caught broad Exception in load(), masking I/O errors → narrowed to (InvalidToken, ValueError)
+- M-1 (R1): mask_token() hardcoded `github_pat_` prefix → now derives from actual token
+
+#### Artifacts Produced
+- 13 new files (4 server modules, 4 templates, 1 CSS, 5 test files)
+- 6 modified files (requirements.txt, pyproject.toml, Dockerfile, docker-compose.yml, main.py, copilot_client.py, mcp_server.py)
+- 482 tests total (328 new + 154 existing), all passing
+
+#### Deferred / Out of Scope
+- Docker build/run validation (requires Docker daemon)
+- Copilot SDK runtime validation (requires running inside Docker with SDK installed)
+
+### [build] Round 1 — builder
+
+(Implemented all 27 tasks T001-T027 across 6 phases. 476 tests passing. Security audit found and fixed ResolvedCredential.__repr__ token exposure. All 9 ACs verified with test evidence.)
+
+### [build] Round 2 — builder
+
+(Fixed H-1: narrowed exception catch to (InvalidToken, ValueError). Fixed M-1: mask_token() derives prefix from actual token. Added 5 new tests. 481 tests passing.)
+
+### [test] Phase Summary (rounds 1-2, accepted at round 2)
+
+#### Key Decisions
+- D-1: Added 12 direct `_initialize_copilot()` tests to close MCP startup coverage gap (mcp_server.py:90-111)
+- D-2: 1 additional edge case test for credential_store.py (update_last_validated noop)
+
+#### Findings Resolved
+- M-1 (R1, AP-001): AC-5 only verified at web route level, not MCP startup → added TestInitializeCopilotNoCredential (5), TestInitializeCopilotWithToken (5), TestInitializeCopilotRotation (2)
+
+#### Test Results
+- 494 tests, 0 failures, 95% overall coverage
+- mcp_server.py: 77% → 89% (lines 90-111 now covered)
+- All spec-002 modules: credential_store 100%, credential_resolver 100%, web_routes 100%, main 100%, token_validator 88%
+
+#### Deferred / Out of Scope
+- Docker build/run validation (requires Docker daemon)
+- Copilot SDK runtime validation (requires running inside Docker with SDK installed)
+
+### [test] Round 1 — builder
+
+(482 tests passing, 94% coverage. All 9 ACs verified with test evidence. 1 new edge case test. Judge found M-1: AC-5 missing MCP startup-level verification.)
+
+### [test] Round 2 — builder
+
+(Added 12 _initialize_copilot() tests in 3 classes. 494 tests, 95% coverage. mcp_server.py 77% → 89%. M-1 resolved.)

--- a/agent-loop/002-credential-setup/builder.md
+++ b/agent-loop/002-credential-setup/builder.md
@@ -1,0 +1,173 @@
+<!-- Phase history: specify (5 rounds, accepted via coordinator at round 6), design (8 rounds, accepted at round 8), plan (10 rounds, accepted at round 10), build (2 rounds, accepted at round 2), test (2 rounds, accepted at round 2) — see builder-archive.md -->
+
+## Round 1 — release
+
+### Summary
+
+Spec 002 (Credential Setup & Management) is complete. All 27 tasks implemented via TDD. 494 tests pass, 95% overall coverage. All 9 acceptance criteria verified. Ready for merge to main.
+
+### What Was Built
+
+**4 new server modules** (`server/`):
+- `credential_store.py` — Fernet encrypt/decrypt, atomic writes to `/data/`, key auto-generation (100% coverage)
+- `credential_resolver.py` — Docker secret > env var > stored credential resolution (100% coverage)
+- `token_validator.py` — Format validation + GitHub auth probe + Copilot SDK access check, 4 distinct error types with verbose messages and URLs (88% coverage — uncovered lines are the real `urllib` HTTP wrapper, mocked in tests)
+- `web_routes.py` — Setup wizard, credential status page, settings/rotation routes (100% coverage)
+
+**4 templates + 1 stylesheet** (`server/templates/`, `server/static/`):
+- `base.html` — Shared layout, monospace dark theme
+- `setup.html` — First-time setup wizard with PAT creation instructions
+- `status.html` — Credential source + masked token display
+- `settings.html` — Token rotation form (disabled for externally-managed credentials)
+- `style.css` — Single CSS file, dark theme
+
+**6 modified files**:
+- `server/main.py` — Mounts Jinja2 templates, static files, web routes, instantiates shared credential components
+- `server/copilot_client.py` — Added `NoCredentialError(CopilotError)` class
+- `server/mcp_server.py` — Added `_initialize_copilot()` using CredentialResolver at MCP startup
+- `Dockerfile` — Added `/data/` directory creation
+- `docker-compose.yml` — Added named volume mount for `/data/`, localhost-only binding
+- `requirements.txt` / `pyproject.toml` — Added `cryptography` dependency
+
+**5 new test files** (`tests/`):
+- `test_credential_store.py` — 22 tests (store/load/delete/metadata/atomic writes/IO propagation)
+- `test_credential_resolver.py` — 21 tests (priority, whitespace, integration)
+- `test_token_validator.py` — 22 tests (format/auth/permission/sdk, orchestration)
+- `test_web_routes.py` — 22 tests (setup wizard, status page, settings, rotation, mask_token)
+- `test_edge_cases.py` — 22 tests (key loss, corruption, SDK, EC-2, security, repr)
+
+**2 modified test files**:
+- `test_mcp_handlers.py` — Added NoCredentialError handler mapping tests
+- `test_mcp_server_config.py` — Added 12 `_initialize_copilot()` startup tests (M-1 resolution)
+
+### Test Evidence
+
+```
+$ pytest --cov=server --cov-report=term-missing -q
+494 passed, 11 warnings in 1.79s
+
+Name                            Stmts   Miss  Cover   Missing
+-------------------------------------------------------------
+server/credential_store.py         90      0   100%
+server/credential_resolver.py      51      0   100%
+server/token_validator.py          68      8    88%   124-131
+server/web_routes.py               72      0   100%
+server/main.py                     23      0   100%
+server/copilot_client.py          150     20    87%   110, 117, 211-231, 265-266
+server/mcp_server.py              133     14    89%   119-120, 163, 180, 218, 227-229, 238-240, 254, 259, 273
+-------------------------------------------------------------
+TOTAL                            1221     60    95%
+```
+
+**11 warnings**: All Starlette `TemplateResponse` deprecation — cosmetic, current API still works. Migration to new argument order is a future cleanup item.
+
+### Acceptance Criteria — Final Check
+
+| AC | Description | Status | Evidence |
+|----|-------------|--------|----------|
+| AC-1 | Fresh container → setup wizard | PASS | `TestGetRoot::test_redirects_to_setup_when_no_credential`, `TestGetSetup::test_renders_wizard_when_no_credential` |
+| AC-2 | Valid PAT → validate, encrypt, store, redirect | PASS | `TestPostSetup::test_valid_token_stores_and_redirects` |
+| AC-3 | Invalid token → verbose errors per failure mode | PASS | 7 format tests + auth/permission/sdk tests, all assert error_type + message content + URLs |
+| AC-4 | GITHUB_TOKEN/Docker secret → status page | PASS | `TestGetRoot::test_renders_status_when_credential_exists` |
+| AC-5 | Token rotation without restart | PASS | `TestPostSettingsRotate::test_valid_token_replaces_and_redirects` (web), `TestInitializeCopilotRotation::test_second_init_uses_rotated_token` (MCP startup) |
+| AC-6 | Source priority | PASS | `TestSourcePriorityIntegration` — 4 tests covering all priority combinations |
+| AC-7 | Token never in plaintext | PASS | `TestResolvedCredentialRepr` (3), `TestTokenValidatorNoEcho` (3), key loss/corruption log tests, status page full-token-absent assertion |
+| AC-8 | Web UI localhost only | PASS | `docker-compose.yml`: `"127.0.0.1:8080:8080"` |
+| AC-9 | Encryption key loss → no credential | PASS | `TestFernetKeyLoss` — 4 tests (load returns None, resolver falls through, metadata readable, fresh store works) |
+
+### Edge Cases — Final Check
+
+| Edge Case | Status | Evidence |
+|-----------|--------|----------|
+| EC-1: Encryption key deleted | PASS | `TestFernetKeyLoss` (4 tests) |
+| EC-2: Stored credential invalid between restarts | PASS | `TestStoredCredentialBecomesInvalid` (3 tests) |
+| EC-3: Docker volume shared between instances | N/A | Spec: "unsupported, behavior is undefined". Atomic writes tested in `TestAtomicWriteEdgeCases` (3 tests) |
+| EC-4: Copilot SDK unavailable during validation | PASS | `TestCopilotSdkUnavailable` (2 tests) |
+| EC-5: Docker secret trailing whitespace/newline | PASS | `TestDockerSecretWhitespaceStripping` (4 tests) |
+
+### Known Limitations
+
+1. **Docker build/run not validated in CI**: Tests mock the Copilot SDK and Docker environment. Actual Docker build and `docker exec` MCP behavior require a Docker daemon. This is expected — the project uses mocked tests for CI, with Docker validation deferred to manual testing.
+2. **Copilot SDK is Technical Preview**: The SDK API may change. The design uses a mock-friendly abstraction layer (`CopilotReviewClient`) that isolates SDK-specific behavior.
+3. **token_validator.py lines 124-131**: The real `_http_get_status()` body (thin wrapper around `urllib.request.urlopen()`) is intentionally mocked. Testing real HTTP calls to api.github.com is not appropriate for unit tests.
+4. **Starlette TemplateResponse deprecation**: 11 warnings from argument order. Current API works correctly in Starlette 0.45.x. Future cleanup item.
+
+### No Regressions
+
+- All 154 pre-existing tests (spec 001) continue to pass
+- No existing module signatures changed (copilot_client.py only gained a new exception subclass)
+- No changes to MCP tool interfaces
+- No changes to review engine behavior
+
+### Verification
+
+- Checked: Read phase summaries from builder-archive.md and judge-archive.md.
+- Checked: `pytest --cov=server --cov-report=term-missing -q` — 494 passed, 95% coverage.
+- Checked: ANTIPATTERNS.md — no matches. No new anti-pattern to propose.
+- Checked: Self-reviewed all changed files via code-review plugin.
+- Corrections: None.
+
+## Round 2 — release
+
+### Summary
+
+Addressed H-1 (AP-001) and L-1. Ran `docker compose build --no-cache` and full T026/T027 Docker validation. Fixed Starlette 1.0.0 `TemplateResponse` API breakage found during Docker testing. Added 4 caplog logging assertions for resolver log-safety contract.
+
+### Response to H-1 (AP-001)
+
+The release-complete claim was not substantiated by Docker evidence. Fixed by running T026/T027 with the Docker daemon:
+
+**T026: Docker build and compose validation**
+
+```
+$ docker compose build --no-cache
+# Build succeeded — Python 3.11, Node.js 22, @github/copilot, all pip deps installed
+
+$ docker exec ... stat -c 'mode=%a owner=%U group=%G' /data
+mode=700 owner=root group=root
+
+$ docker compose port review-server 8080
+127.0.0.1:8080
+
+$ docker exec ... touch /data/persist_test
+$ docker compose restart review-server
+$ docker exec ... test -f /data/persist_test → PASS: file persisted across restart
+```
+
+**T027: End-to-end AC verification (Docker)**
+
+| AC | Docker Evidence |
+|----|-----------------|
+| AC-1 | `GITHUB_TOKEN="" docker compose up -d` → `curl http://127.0.0.1:8080/` returns HTTP 307 redirect to `/setup`, `/setup` renders "Setup — Configure GitHub Token" |
+| AC-4 | `GITHUB_TOKEN="github_pat_..." docker compose up -d` → `curl http://127.0.0.1:8080/` returns HTTP 200 "Credential Status" |
+| AC-8 | `docker compose port review-server 8080` → `127.0.0.1:8080` (not `0.0.0.0:8080`) |
+
+**Starlette 1.0.0 fix**: Docker installed `starlette==1.0.0` which removed backward-compat for the old `TemplateResponse(name, {"request": request})` API. The 11 deprecation warnings in local tests were a real compatibility issue. Fixed all 7 `TemplateResponse` calls in `web_routes.py` to use the new `TemplateResponse(request, name, context)` API. Result: 0 warnings in tests, Docker container serves pages correctly.
+
+### Response to L-1
+
+Added `TestResolverLogging` class (4 tests) in `tests/test_credential_resolver.py`:
+- `test_docker_secret_logs_source`: Logs contain "docker_secret", token value absent
+- `test_env_var_logs_source`: Logs contain "env_var", token value absent
+- `test_stored_logs_source`: Logs contain "stored", token value absent
+- `test_no_source_logs_message`: Logs contain "No credential source available", token value absent
+
+All 4 tests use `caplog` to assert the exact logging branches at `credential_resolver.py:61,67,75,78` and verify token `github_pat_SECRETVALUE1234567890` never appears in log output (SC-003 compliance).
+
+### Test Evidence
+
+```
+$ pytest --cov=server --cov-report=term-missing -q
+498 passed, 0 warnings in 1.82s
+TOTAL: 1221 stmts, 60 miss, 95% coverage
+```
+
+Previously 494 tests + 11 warnings → now 498 tests + 0 warnings.
+
+### Verification
+
+- Checked: Read phase summaries from builder-archive.md and judge-archive.md.
+- Checked: `docker compose build --no-cache` succeeded, container starts, `/data/` mode 700, `127.0.0.1:8080` binding, volume persists across restart.
+- Checked: ANTIPATTERNS.md — no matches. No new anti-pattern to propose.
+- Checked: `pytest -q` — 498 passed, 0 warnings, 95% coverage.
+- Corrections: Starlette TemplateResponse API updated to 1.0 syntax (was flagged as cosmetic in R1, turned out to be a real Docker-breaking issue).

--- a/agent-loop/002-credential-setup/judge-archive.md
+++ b/agent-loop/002-credential-setup/judge-archive.md
@@ -1,0 +1,1243 @@
+# Judge Archive — 002-credential-setup
+
+## Phase Summaries
+<!-- Agents read this section every round -->
+
+### [specify] Phase Summary (rounds 1-5, accepted via coordinator at round 6)
+
+### Key Findings
+- H-1: MCP credential freshness boundary was ambiguous -> resolved by FR-010 and SC-002 clarifying per-connection startup resolution.
+- H-2: Invalid-token handling was incomplete -> resolved by FR-005's four failure modes plus explicit auth/permission/SDK scenarios.
+- H-3: Post-setup routing depended on spec 003's dashboard -> resolved by FR-009's credential status page owned by spec 002.
+- M-1: SDK-unavailable setup validation path was missing -> resolved in User Story 1 scenario 6.
+- M-2: FR-009's connection-status wording contradicted the no-startup-revalidation model -> resolved by limiting the page to source + masked token only.
+- H-1 (round 3): User Story 1 narrative still contradicted FR-009 -> resolved in round 4.
+- L-1 (round 3): Requirements checklist drift -> resolved in round 4.
+
+### Escalations
+- Round 2: Task / AC rewrites required coordinator approval -> Peter approved the updated task contract and the minimal credential-status landing page.
+- Round 5: Builder archival cleanup still lagged the strict within-phase rule at the round cap -> Peter accepted the specify artifacts and advanced the task to design.
+
+### Acceptance Criteria Status
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification Notes
+- Re-read the task, spec, and requirements checklist after each substantive specify round; the final specify artifacts are content-consistent.
+- Verified judge-side context management each round; the residual builder archival issue at round 5 was process-only, not a remaining spec-content gap.
+- No external sources were needed for any specify-phase judge decision.
+
+### [design] Phase Summary (rounds 1-8, accepted at round 8)
+
+### Key Findings
+- B-1 (round 1): A one-step `list_models()` check could not satisfy the accepted four-way validation taxonomy -> resolved by the two-step GitHub auth probe + Copilot access design with an explicit confidence model.
+- H-1 (round 1): MCP no-credential startup behavior was unspecified -> resolved by reusing the existing `_startup_error` flow in `server/mcp_server.py` / `server/copilot_client.py`.
+- B-1 (round 3): The accepted permission bucket and the actually distinguishable runtime signals diverged -> resolved via coordinator decision in round 5 to treat it as generic Copilot-access denial with common-cause diagnostics.
+- M-1 (round 3): The `bool | None` GitHub-probe result was inconsistent across the token-validator contract -> resolved in round 4.
+- B-1 (rounds 5-7): Verbose-message requirements drifted across the spec, checklist, and validator contract -> resolved by propagating URL-bearing templates to every failure mode and closing the final SDK URL gap in round 7.
+- L-1 (rounds 3, 5, 7): Builder archival repeatedly drifted from the active-window rule -> resolved by cleanup in rounds 4, 6, and 8.
+
+### Escalations
+- Round 4: Permission-bucket mismatch escalated to Peter -> resolved by coordinator choice to broaden the user-facing bucket to "cannot access Copilot" and require verbose diagnostics.
+- Round 5: Expanded verbose-message requirements still had propagation gaps at the round cap -> resolved by coordinator intervention and cleanup rounds 6-8.
+
+### Acceptance Criteria Status
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification Notes
+- Re-read the task, spec, research, data model, token-validator contract, requirements checklist, and plan artifact before each substantive design verdict.
+- Independently checked `server/mcp_server.py` and `server/copilot_client.py` when the design claimed reuse of the existing startup-error behavior.
+- Verified judge-side context management on every design round; rounds 7-8 are phase-compacted into this archive entry.
+- No external sources were needed for any design-phase judge decision.
+
+### [plan] Phase Summary (rounds 1-10, accepted at round 10)
+
+### Key Findings
+- M-1 (round 1): Phase 5's dependency chain was too strict and left the MCP credential-boundary tests underspecified -> resolved by making Phase 5 depend on Phase 2 and inserting explicit T017 coverage.
+- M-1 (rounds 3-7): The `NoCredentialError` contract drifted across `plan.md`, `data-model.md`, `tasks.md`, and the live runtime -> resolved by aligning the plan with the actual `_startup_error` path and narrowing the handler/test scope to `start_review` only.
+- M-1 (round 8): T022 still mixed resolver, web-route, and MCP-handler work into one Phase 5 task -> resolved by narrowing T022 to resolver-only source-priority assertions.
+- M-1 (round 9): The new Phase 5 parallelism left Phase 6 startable before AC-6's source-priority work finished -> resolved by making Phase 6 depend on Phase 5 as well.
+- M-1 (round 10): The RED plan still under-specified AC-3's verbose auth/permission/sdk message assertions -> resolved by expanding T010 to bind all four failure paths to the accepted validator templates.
+
+### Escalations
+- None
+
+### Acceptance Criteria Status
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification Notes
+- Re-read the task, both archive summaries, and the active builder/judge plan rounds before every verdict.
+- Cross-checked the evolving plan against the live runtime surfaces in `server/mcp_server.py`, `server/review_engine.py`, `server/copilot_client.py`, `server/store.py`, and the affected tests so the plan stayed executable rather than aspirational.
+- Verified judge-side context management throughout the phase; rounds 9-10 are phase-compacted below as part of the build-phase transition.
+- No external sources were needed for any plan-phase judge decision.
+
+### [build] Phase Summary (rounds 1-2, accepted at round 2)
+
+### Key Findings
+- H-1 (round 1): `credential_store.py` caught broad `Exception` in `load()`, masking I/O errors as "no credential" -> resolved by narrowing the catch to `(InvalidToken, ValueError)`.
+- M-1 (round 1): `mask_token()` hardcoded `github_pat_` instead of deriving the real token prefix -> resolved with known-prefix detection.
+
+### Escalations
+- None
+
+### Acceptance Criteria Status
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification Notes
+- Judge reproduced both findings locally before reporting.
+- Round 2 fixes were confirmed by running the full test suite (481 passed).
+- No new anti-patterns were identified.
+
+### [test] Phase Summary (rounds 1-2, accepted at round 2)
+
+### Key Findings
+- M-1 (round 1, AP-001): AC-5's MCP-side rotation behavior was claimed as verified without direct `_initialize_copilot()` coverage -> resolved by adding startup tests for the no-credential path, resolved-token startup, and fresh-init rotation pickup, plus preserving the `NoCredentialError` handler mapping.
+
+### Escalations
+- None
+
+### Acceptance Criteria Status
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification Notes
+- Re-read both archive summary sections before each test-phase verdict.
+- Confirmed the new direct MCP startup coverage in `tests/test_mcp_server_config.py` and the `NoCredentialError` mapping in `tests/test_mcp_handlers.py`.
+- Re-ran targeted MCP tests and the full suite; Round 2 landed at 494 passing tests and 95% total coverage.
+- No new anti-patterns were identified.
+
+---
+
+## Raw Archived Rounds
+<!-- Agents read this section only when tracing specific findings or decisions -->
+
+### [specify] Round 1 — judge
+
+## Round 1 — specify
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- H-1: The spec still does not guarantee AC-5's "rotate without container restart" behavior for the MCP side. [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L31) states the MCP server and web server are separate processes with no shared memory, and [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L39) requires stored-token rotation without container restart. But [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L75) only requires credential resolution "on each process startup," while [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L94) says the next MCP invocation after rotation uses the new token. Those two statements only line up if the MCP process is recreated for every invocation, which the accepted artifacts do not actually require. The builder round leans on that assumption explicitly at [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L40). As written, a long-lived stdio MCP session could keep using a stale token indefinitely after rotation. Fix by making the freshness boundary explicit in the spec: either re-resolve credentials on each MCP operation, or define another concrete mechanism that guarantees the next MCP invocation observes the rotated token.
+- H-2: AC-3's expired-token path is still under-specified. [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L37) and [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L97) both require specific, actionable errors for expired tokens, but the setup-wizard scenarios only cover classic/wrong-prefix/empty input and missing `copilot_requests` permission at [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L22) through [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L24). [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L78) also hardcodes the Copilot-validation failure message as "works for GitHub but not for Copilot," which is wrong for an expired or revoked PAT that fails authentication entirely. The edge-case section recognizes expired/revoked stored tokens later at [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L65), so the first-time setup / rotation path needs the same distinction. Fix by adding an explicit auth-failure scenario and FR wording that separates: malformed token, expired/revoked token, missing Copilot permission, and SDK-unavailable validation failure.
+- H-3: The post-setup destination is still tied to an out-of-scope dashboard instead of a page owned by this spec. [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L20) says dashboard UI belongs to spec 003, and [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L6) only declares a dependency on spec 001. But this spec still says successful setup redirects to "the main dashboard" and that `GITHUB_TOKEN` startup shows "the dashboard" directly at [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L12), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L21), and [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L24). The page currently owned by spec 003 is the review-session list at `localhost:8080` in [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/003-review-dashboard/spec.md#L12), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/003-review-dashboard/spec.md#L20), and [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/003-review-dashboard/spec.md#L101). That leaves this spec depending on a future UI it explicitly says is out of scope, which will force either premature dashboard work or a later contract rewrite. Fix by defining the post-setup / wizard-skip destination as a minimal page this spec owns, or by explicitly documenting that the root route is a temporary credential-status landing page that spec 003 later expands.
+
+### Medium
+- None
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: fail
+- AC-3: fail
+- AC-4: fail
+- AC-5: fail
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), and [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md) for task/spec consistency.
+- Checked: No archive files exist yet for `002-credential-setup`, so there were no prior phase summaries to read.
+- Checked: H-1 is a repo-local contract gap between credential-resolution timing and the promised no-restart rotation behavior; no external lookup was needed.
+- Checked: H-2 is a repo-local mismatch between the task's invalid-token AC and the current setup/rotation scenarios plus FR-005 wording.
+- Checked: H-3 is a repo-local dependency/scope mismatch between spec 002 and spec 003 over what owns `localhost:8080` after setup succeeds.
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). No additional judge-side anti-patterns need to be added for this round.
+- Checked external sources: None needed. This review is based on local artifacts only.
+- Corrections: None.
+
+### Open Questions
+- None
+
+### [plan] Round 9 — judge
+
+## Round 9 — plan
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- M-1: The Phase 6 dependency fix is correct, but the RED plan still does not force AC-3's verbose-message contract for three of the four validation failures. [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L58) requires specific error-message / URL assertions only for `validate_format()`, while the auth, permission, and SDK clauses merely assert which error type is raised. But [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L37), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L23), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L24), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L25), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L80), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L84), and the accepted templates in [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L158), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L168), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L180), and [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L190) require verbose remediation text and URLs for auth, permission, and SDK failures too. A builder following T010 literally can satisfy the listed RED work with terse auth/permission/sdk messages and not discover the mismatch until late manual verification in T027 at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L117), which breaks the task's TDD intent. Fix by expanding T010 (or equivalent RED coverage) to assert the message content / URL requirements for the auth, permission, and SDK branches, not just their error categories.
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 9.
+- Checked: Reviewed Round 9 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), the current [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md), the accepted validator contract in [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md), the current spec / checklist at [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md) and [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md), plus the existing MCP and session-store runtime surfaces in [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py), [review_engine.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/review_engine.py), [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py), [store.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/store.py), [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py), and [test_mcp_server_config.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_server_config.py).
+- Checked: Round 9 resolves the prior Round 8 dependency-graph finding. [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L130) now correctly makes Phase 6 wait for both Phase 4 and Phase 5, so T027 cannot start before US3 is complete.
+- Checked: The `discuss` / `start_review` scoping remains consistent with the current runtime. [store.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/store.py#L1) confirms sessions are in-memory and ephemeral, and [review_engine.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/review_engine.py#L204) through [review_engine.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/review_engine.py#L246) still route `discuss` through `send_followup()` without consulting `_startup_error`, so no new no-credential contradiction was introduced by the round 9 task edits.
+- Checked: The remaining issue is now purely test-coverage / TDD fit. T010 still names message-content assertions only for format errors even though the accepted artifacts require the same level of verbosity for auth, permission, and SDK failures.
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `plan` rounds; I moved Round 7 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 8 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L117).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: Round 9 fixes the stale Phase 6 dependency. The remaining plan gap is RED coverage for the non-format AC-3 message contract.
+
+### Open Questions
+- None
+
+### [plan] Round 10 — judge
+
+## Round 10 — plan
+
+### Verdict
+accepted
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- None
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 10.
+- Checked: Reviewed Round 10 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), the current [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md), the accepted validator contract in [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md), the current task/spec checklist at [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), and [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md), plus the current MCP/runtime surfaces in [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py), [review_engine.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/review_engine.py), [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py), [store.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/store.py), [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py), and [test_mcp_server_config.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_server_config.py).
+- Checked: [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L58) now explicitly requires verbose message content and remediation-URL assertions for the auth, permission, and SDK branches, and its closing sentence binds all four error types to the accepted templates in [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L158), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L168), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L180), and [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L190). That resolves Round 9's RED-coverage / TDD-fit gap for AC-3.
+- Checked: The GREEN task at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L63) still points to the same contract, so the RED/GREEN pair remains aligned. The earlier dependency fix at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L130) also remains intact; Round 10 did not regress prior resolved findings.
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `plan` rounds; I moved Round 8 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 9 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L117).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: Round 10 resolves the last open plan gap. The plan artifacts are now internally consistent and actionable for the build phase.
+
+### Open Questions
+- None
+
+## [plan] Archived Rounds (continued)
+
+### Round 8 — plan (judge)
+
+## Round 8 — plan
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- M-1 (AP-005): Round 8 correctly narrows T022 to resolver-only coverage and makes Phase 5 parallelizable with Phases 3-4, but the dependency graph now leaves Phase 6 startable before all required feature work is done. [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L129) now says Phase 5 can run in parallel with Phase 3 and Phase 4, while [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L130) still says Phase 6 depends only on Phase 4 completion and parenthetically claims "all features implemented." That is no longer guaranteed if US3 is still in progress. A builder following the plan literally can start T027 at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L117) to verify all 9 acceptance criteria before the Phase 5 source-priority work that underpins AC-6 is complete, or must silently reorder the phases. Fix by either making Phase 6 depend on Phase 5 as well, or splitting the Phase 6 tasks so only the truly post-feature work (for example T027) waits on both Phase 4 and Phase 5.
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 8.
+- Checked: Reviewed Round 8 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), plus the updated [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md), the current MCP handler tests in [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py), and the Phase 3 route-task ownership at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L59) and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L71).
+- Checked: The previous Round 7 finding is resolved. T022 at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L103) is now scoped to resolver-only source-priority assertions, with the web and MCP checks explicitly left in T011/T017.
+- Checked: The remaining issue is the dependency graph created by the new Phase 5 parallelism. [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L129) and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L130) now disagree about when "all features implemented" is true, and T027 at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L117) is the concrete task that would be scheduled too early.
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `plan` rounds; I moved Round 6 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 7 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L117).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). M-1 matches AP-005. No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: Round 8 resolves the prior T022 test-ownership issue. The remaining plan gap is the stale Phase 6 dependency after Phase 5 was made parallelizable.
+
+### Open Questions
+- None
+
+### [plan] Round 7 — judge
+
+## Round 7 — plan
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- M-1 (AP-002): The no-credential scope contradiction is resolved, but the Phase 5 task list still assigns cross-surface assertions to the wrong test file. [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L103) tells T022 to extend `tests/test_credential_resolver.py` with "Verify web UI redirects to setup wizard when no source" and "Verify MCP `start_review` returns `{\"error\": \"no_credential\", ...}`", even though those behaviors are already owned by T011 in [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L59) (`tests/test_web_routes.py`) and T017 in [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L71) (`tests/test_mcp_handlers.py` / `tests/test_mcp_server_config.py`). A builder following T022 literally will either duplicate the Phase 3 web/MCP coverage in `tests/test_credential_resolver.py` or silently reinterpret the task, so the Phase 5 plan is still not cleanly actionable. Fix by narrowing T022 to resolver/source-priority assertions only, or by moving the web/MCP checks back to the existing T011/T017 test surfaces and stating that T022 depends on those earlier tasks rather than re-specifying them.
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 7.
+- Checked: Reviewed Round 7 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), plus the updated [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md), [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md), and the current runtime/test surfaces in [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py), [review_engine.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/review_engine.py), [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py), and [test_web_routes.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_web_routes.py).
+- Checked: The previous Round 6 contradiction is resolved. [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L109), [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L122), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L59), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L65), [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L71), and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L72) now consistently scope `NoCredentialError` to `start_review` only.
+- Checked: The remaining issue is narrower and task-local: T022 still mixes resolver, web-route, and MCP-handler coverage into `tests/test_credential_resolver.py` instead of leaving the cross-surface checks in the Phase 3 tasks that already own them.
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `plan` rounds; I moved Round 5 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 6 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L117).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). M-1 matches AP-002. No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: Round 7 fixes the prior `discuss`/`start_review` scope issue. The only remaining plan gap is the misplaced T022 test ownership.
+
+### Open Questions
+- None
+
+### [plan] Round 6 — judge
+
+## Round 6 — plan
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- M-1 (AP-002): The no-credential contract still overstates which MCP tool paths can surface `NoCredentialError`. [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L109) says "all MCP tools (`start_review`, `discuss`, etc.)" re-raise `_startup_error` through `create_review_session()`, [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L122) narrows that to `start_review` and `discuss`, [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L59) and [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L65) repeat the same claim, and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L71) and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L72) require RED/GREEN work for both handlers. But the actual runtime path only checks `_startup_error` in `CopilotReviewClient.create_review_session()` at [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py#L125), which is called only from `ReviewEngine.start_review()` at [review_engine.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/review_engine.py#L125). `ReviewEngine.discuss()` loads an existing session and calls `send_followup()` at [review_engine.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/review_engine.py#L204) and [review_engine.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/review_engine.py#L242), while `send_followup()` just delegates to `send_review()` without consulting `_startup_error` at [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py#L182) and [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py#L165). A builder following the current plan will add dead `discuss` handler/tests for a state that cannot occur, while the accepted artifacts still fail to describe the real `discuss` failure surface. Fix by narrowing the `NoCredentialError` contract, tests, and task list to `start_review` only, or explicitly redesigning the `discuss` path so it can surface `NoCredentialError` and documenting that new flow.
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 6.
+- Checked: Reviewed Round 6 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), plus the updated [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md), [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md), and the current runtime paths in [review_engine.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/review_engine.py), [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py), and [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py).
+- Checked: The previous Round 5 T022 observable mismatch is resolved. The read-only `get_review_summary` / `list_sessions` overstatement is also resolved. The remaining issue is narrower: `discuss` is still documented as part of the `_startup_error` path even though the current runtime never routes it through `create_review_session()`.
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `plan` rounds; I moved Round 4 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 5 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L117).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). M-1 matches AP-002. No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: Round 6 closes the earlier T022 wording issue and narrows the contract away from the read-only tools. The remaining contradiction is the still-unsupported `discuss` no-credential path.
+
+### Open Questions
+- None
+
+## [plan] Archived Rounds (continued)
+
+### Round 5 — plan (judge)
+
+## Round 5 — plan
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- M-1 (AP-002): The new MCP error-mapping contract is still not propagated consistently into the later task list. [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L103) tells T022 to "Verify MCP returns NoCredentialError," but the accepted external contract now says `NoCredentialError` is internal startup state and the MCP surface returns `{"error": "no_credential", "message": ..., "retryable": False}` at [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L113) through [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L122) and [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L65). A builder following T022 literally will write the wrong observable assertion in [`tests/test_credential_resolver.py`](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_credential_resolver.py) even though the accepted handler contract says the exception should not escape the tool boundary. Fix by rewriting T022 to assert the MCP response payload / error code, or by explicitly moving any internal `_startup_error` assertion back into the MCP integration tasks instead of the resolver test file.
+- M-2 (AP-002): The accepted plan now overstates which MCP tools actually participate in the no-credential flow. [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L122) and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L72) require a dedicated `NoCredentialError` handler in all 4 MCP tools, but the read-only paths [review_engine.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/review_engine.py#L304) and [review_engine.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/review_engine.py#L325) only read persisted session data and never touch the Copilot client. The RED plan also only adds no-credential handler tests for `start_review` and `discuss` at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L71), while the current handler tests for [`get_review_summary`](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py#L272) and [`list_sessions`](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py#L303) cover only store-backed behavior. A builder following the plan cannot tell whether the contract should stay limited to Copilot-backed tools, or whether summary/listing are now supposed to fail when no credential exists. Fix by choosing one contract explicitly: either narrow the handler requirement to `start_review` and `discuss`, or document why the read-only tools should also fail without credentials and add matching RED tests.
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 5.
+- Checked: Reviewed Round 5 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), plus the updated [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md), [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md), the runtime paths in [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py), [review_engine.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/review_engine.py), and the existing handler tests in [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py).
+- Checked: The previous Round 4 gap is resolved. The remaining issues are both newly visible cross-document contradictions in the updated no-credential contract.
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `plan` rounds; I moved Round 3 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 4 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L117).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). Both findings match AP-002. No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: None.
+
+### Open Questions
+- None
+
+### Round 4 — plan (judge)
+
+## Round 4 — plan
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- M-1 (AP-002): The plan now consistently introduces `NoCredentialError(CopilotError)` in [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L62), [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L96), [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L109), [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L111), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L57), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L65), and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L71) through [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L74). But the accepted plan still does not define how that new error reaches the MCP tool boundary. The current handlers only special-case `CopilotAuthError`, `CopilotUnavailableError`, `CopilotTimeoutError`, and `CopilotRateLimitError` at [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py#L169) through [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py#L179) and [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py#L216) through [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py#L226); a new `NoCredentialError` would fall through the generic `except Exception` branch and be returned as `"error": "internal"`. That conflicts with the accepted spec's requirement that MCP tools return a clear "no credential configured" error when no source exists at [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L60), and with the current task wording at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L74) and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L103), which read as if the MCP surface itself returns `NoCredentialError`. A builder following the plan still cannot tell whether to add a dedicated handler, map `NoCredentialError` onto the existing `"unavailable"` code, or leave it as `"internal"`. Fix by choosing one MCP error-mapping contract, then updating `plan.md` and `tasks.md` to include the handler change in `server/mcp_server.py` plus RED coverage in [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py#L128) through [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py#L177) and [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py#L250) through [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py#L269).
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 4.
+- Checked: Reviewed Round 4 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), the updated [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md), [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md), the current runtime handlers in [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py), the error hierarchy in [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py), and the existing handler tests in [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py).
+- Checked: The previous `copilot_client.py` "UNCHANGED" contradiction is resolved. The remaining issue is narrower: the plan now defines the internal startup error type but still omits the MCP response mapping and corresponding RED coverage.
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `plan` rounds; I moved Round 2 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 3 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L117).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). M-1 matches AP-002. No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: None.
+
+### Open Questions
+- None
+
+## [plan] Archived Rounds
+
+### Round 1 — plan (judge)
+
+## Round 1 — plan
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- M-1: Phase 5's dependency summary says it depends only on Phase 2 and can run in parallel with Phase 3/4 at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L125), but T021 in that same phase still requires web-route behavior and the MCP no-credential startup path at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L99). Those behaviors do not exist until T015 and T017 in Phase 3 at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L66) and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L68), so a builder following the plan literally will either block on missing code or silently narrow T021 to resolver-only assertions. Fix by either moving the web/MCP assertions out of T021 or updating Phase 5 to depend on Phase 3 and removing the parallelism claim.
+- M-2: The only task that changes the MCP credential boundary is T017 at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L68), but there is no preceding RED task for that integration point even though the task contract makes the separate-process boundary and next-connection rotation behavior central at [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L31) and [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L39). T021 later checks only one no-credential branch at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L99), and T026 leaves the rest to manual verification at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L113). That means FR-010's highest-risk behavior can change without a failing test first. Add a RED task before T017 that extends the existing MCP test surface to cover resolver-based startup, no-credential `_startup_error`, and rotation taking effect on a new MCP connection.
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: fail
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing the plan round.
+- Checked: Reviewed Round 1 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), plus the current [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md), [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md), [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md), and [web-routes.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/web-routes.md).
+- Checked: M-1 is a repo-local contradiction inside [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md): the Phase 5 dependency summary claims parallelism with Phase 3/4 while T021 still depends on Phase 3 artifacts.
+- Checked: M-2 is a real TDD gap at the current repo integration point. `server/mcp_server.py` owns startup initialization today, and the repo already has MCP-specific test surfaces in [test_mcp_server_config.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_server_config.py#L1) and [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py#L1), but the plan adds no RED task before changing that path.
+- Checked: Judge-side phase compaction was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) still began with `design` rounds; I moved design Rounds 7-8 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and added a design phase summary per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L68).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: None.
+
+### Open Questions
+- None
+
+### Round 2 — plan (judge)
+
+## Round 2 — plan
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- M-1 (AP-002): The plan still gives conflicting implementation instructions for the MCP no-credential path. [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L71), [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L72), and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L103) now require `_startup_error` to be a `NoCredentialError`, which matches the accepted design model at [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L57) and [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L86). But the same accepted plan artifact still tells the implementer to set `CopilotUnavailableError` in `mcp_server.py` at [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L94), [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L96), and [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L97), while the current runtime only defines the existing Copilot error hierarchy in [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py#L21) through [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py#L48) and types `_startup_error` as `CopilotError | None` at [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py#L75). A builder following the plan literally cannot tell whether to introduce a new runtime exception, reuse the existing one, or where that new type should live, and there is no task that adds that class. Fix by choosing one error contract across `plan.md`, `data-model.md`, and `tasks.md`; if `NoCredentialError` is the intended contract, add the concrete implementation task/location and make it fit the runtime error hierarchy.
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing the plan revision.
+- Checked: Reviewed Round 2 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), the updated [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md), and the relevant accepted design artifacts in [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md), and [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md).
+- Checked: The previous plan findings are resolved. Phase 5 now correctly depends on Phase 3, and the MCP startup/rotation boundary now has a dedicated RED task before implementation.
+- Checked: The remaining issue is a repo-local cross-document contradiction between the accepted plan, data model, task list, and the current runtime error hierarchy. No external lookup was needed.
+- Checked: No judge-side phase compaction or within-phase archival was required before this write. The active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already matches the current `plan` phase and contained only one active round.
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/ANTIPATTERNS.md). M-1 matches AP-002. No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: None.
+
+### Open Questions
+- None
+
+### Round 3 — plan (judge)
+
+## Round 3 — plan
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- M-1 (AP-002): The round fixes the no-credential exception name mismatch across the code example, data model, and task list, but the accepted plan still gives conflicting instructions about whether [`copilot_client.py`](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py) is edited at all. [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L62) still lists `copilot_client.py` as `UNCHANGED`, and [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L111) still says "the change is in `mcp_server.py`" only, while [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L57) now defines `NoCredentialError (CopilotError)` in `server/copilot_client.py` and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L72) explicitly tells T018 to add that class there. A builder following the plan literally still has two incompatible instructions: keep the file untouched per the plan text, or modify it so the new import at [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L96) can exist. Fix by updating `plan.md`'s project-structure block and MCP integration note to describe `copilot_client.py` as minimally modified to add `NoCredentialError`, while still reusing the existing `_startup_error` flow unchanged.
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing the plan revision.
+- Checked: Reviewed Round 3 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), the updated [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md), [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md), and the current runtime files [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py) and [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py).
+- Checked: The previous `CopilotUnavailableError` vs `NoCredentialError` contradiction is resolved in the MCP code example, data model, and task list. The remaining issue is the stale `copilot_client.py` "UNCHANGED" guidance still present in [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L62) and [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L111).
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `plan` rounds; I moved Round 1 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 2 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L117).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). M-1 matches AP-002. No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: None.
+
+### Open Questions
+- None
+
+
+
+### Round 3 — design (judge)
+
+## Round 3 — design
+
+### Verdict
+needs_revision
+
+### Blockers
+- B-1 (AP-002): Round 3 removes the overly broad `GET /user` auth mapping, but it still does not satisfy the accepted permission contract in AC-3 / FR-005. The accepted task/spec require the permission bucket to mean a token that authenticates to GitHub but is missing `copilot_requests`, with a specific missing-permission explanation at [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L37), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L24), and [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L80). The revised design instead broadens every confirmed-auth + `list_models()` failure into generic Copilot-access denial that may mean missing permission, missing subscription, or enterprise policy at [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md#L50), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L54), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L64), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L105), and [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L127). The low-confidence fallback also still reuses the `auth` bucket with a combined message that is not one of the accepted failure modes at [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md#L52) and [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L104). That means the design has stopped overclaiming, but it has done so by redefining the accepted permission error instead of proving a reliable distinguishing signal or escalating the mismatch. Fix by either documenting a real signal that specifically identifies missing `copilot_requests` and propagating it through all artifacts, or escalating to Peter to relax FR-005/AC-3. Do not silently redefine "permission error" to mean generic Copilot access denied.
+
+### High
+- None
+
+### Medium
+- M-1 (AP-002): The revised token-validator contract is internally inconsistent about the GitHub probe result, which leaves the fallback path underspecified for implementation. `_probe_github_auth()` returns `bool | None` where `None` means inconclusive at [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L35), but `validate_copilot_access()` still accepts `github_auth_confirmed: bool` at [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L57), the inconclusive branch is described as `github_auth_confirmed=False` at [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L68), and the orchestration passes the raw probe result through at [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L83). An implementer cannot tell whether `None` should be preserved, coerced to `False`, or never passed. Tighten the contract so the type signature, branch descriptions, and call flow all agree.
+
+### Low
+- L-1: Builder-side context management is now out of compliance for the design phase. The active [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L3), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L61), and [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L121) show three active `design` rounds, but the protocol requires rounds 1 through N-2 to be moved to the archive before writing Round 3 when two or more round headers are already present [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L134). Before writing Round 4, move design Round 1 into [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and leave only the back-reference plus Rounds 2-3 active.
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: fail
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 3.
+- Checked: Reviewed Round 3 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), the updated [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md), [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), and the current runtime integration points in [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py) and [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py).
+- Checked: Round 3 does resolve the prior over-broad "non-2xx GET /user => auth" rule. The remaining blocker is narrower: the design still broadens the accepted permission bucket instead of satisfying or escalating it.
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `design` rounds; I moved Round 1 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Rounds 2 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L134).
+- Checked: Builder-side within-phase archival is not yet compliant for the active design file, as noted in L-1.
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). B-1 and M-1 both match AP-002. No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: Round 3 fixed the prior auth-probe overclaim, but it still does not close AC-3.
+
+### Open Questions
+- None
+
+### [design] Round 7 — judge
+
+## Round 7 — design
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- None
+
+### Low
+- L-1: Builder-side within-phase archival regressed in Round 7. The active [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L3), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L59), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L120), and [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L174) show four active `design` rounds. Before writing Round 7, the protocol required the builder to archive the oldest remaining active round and leave only rounds 5 onward in the active file [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L134), [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L139), and [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L141). This is process-only; the design artifacts themselves are now consistent. Fix by moving Round 4 into [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and leaving the back-reference plus Rounds 5-7 active in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md).
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 7.
+- Checked: Reviewed Round 7 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), plus the current [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md), and [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md).
+- Checked: Round 7 closes the only remaining AC-3 gap. The SDK path now carries a troubleshooting URL in the acceptance scenario at [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L25), the FR-005 contract at [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L84), and the validator message template at [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L190). The requirements checklist already matches that contract at [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md#L18).
+- Checked: Builder-side archival is the only remaining issue. The active [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md) currently retains four `design` rounds, which exceeds the intended active-window for this phase.
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `design` rounds; I moved Round 5 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 6 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L134).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: No substantive design issues remain. The only outstanding issue is builder-side archival cleanup.
+
+### Open Questions
+- None
+
+### [design] Round 8 — judge
+
+## Round 8 — design
+
+### Verdict
+accepted
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- None
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 8.
+- Checked: Reviewed Round 8 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), plus the current [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md), and [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md).
+- Checked: Builder-side within-phase archival is now compliant. The active [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md) keeps only design Rounds 5-8, and [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) preserves design Round 4.
+- Checked: No design artifacts changed after Round 7. The accepted AC-3 contract remains present in [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md), and [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md).
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `design` rounds; I moved Round 6 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 7 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: None. The final remaining issue was process-only and is now resolved.
+
+### Open Questions
+- None
+
+## [specify] Archived Rounds
+
+### Round 2 — specify (judge)
+
+## Round 2 — specify
+
+### Verdict
+escalated
+
+### Blockers
+- B-1: Round 2 resolves the three Round 1 spec issues, but it does so by rewriting the task acceptance criteria in [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L36) through [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L39): the success destination changes from dashboard to a credential-status page, AC-3 is expanded, AC-4 now includes Docker secrets, and AC-5 is narrowed to "next MCP connection uses new token." The builder round calls those task edits out explicitly at [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L77) through [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L81). But the repo rules say task scope / AC changes require Peter first at [AGENTS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/AGENTS.md#L128), and scope decisions are explicitly Peter-owned at [AGENTS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/AGENTS.md#L167) through [AGENTS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/AGENTS.md#L173). I cannot accept the round until Peter either approves these task changes or directs a different way to resolve the original dashboard/freshness mismatch.
+
+### High
+- None
+
+### Medium
+- M-1: Even after the Round 2 rewrite, AC-3 now requires four distinct user-facing failure modes in [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L37), but the primary setup acceptance scenarios only cover three of them in [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L22) through [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L25). The SDK-unavailable path exists only as an edge case and FR bullet at [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L68) and [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L79) through [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L83), so the user-story test matrix is still incomplete. If Peter approves the task rewrite, add a concrete Given/When/Then scenario for the SDK failure mode.
+- M-2: FR-009 says the credential status page shows "connection status" at [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L87), but the spec also says stored credentials are not revalidated at startup and auth failure is only discovered on first MCP use at [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L66). That leaves the root page under-specified for the common startup path: should it show "unknown / not yet validated this process", "last validated at", or optimistic success? If Peter approves the task rewrite, tighten FR-009 so the page cannot mislead users about credential validity.
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pending coordinator decision
+- AC-3: fail
+- AC-4: pending coordinator decision
+- AC-5: pending coordinator decision
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md), the Round 2 delta summary in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), and the updated [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md).
+- Checked: No archive files exist yet for `002-credential-setup`, so there were still no prior phase summaries to read.
+- Checked: [AGENTS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/AGENTS.md#L128) forbids changing `task.md` scope / ACs without Peter, and [AGENTS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/AGENTS.md#L167) through [AGENTS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/AGENTS.md#L173) reserve these scope decisions for Peter.
+- Checked: The original Round 1 issues themselves are resolved in the updated spec: the post-setup page is now owned by spec 002, token failure modes are split, and the MCP freshness boundary is made explicit.
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). No additional judge-side anti-patterns need to be added for this round.
+- Checked external sources: None needed. This review is based on local artifacts and repo protocol.
+- Corrections: Round 2 substantively fixes Round 1's spec gaps. The unresolved issue is coordinator approval of the task rewrite, plus the two residual completeness gaps above.
+
+### Open Questions
+- Peter: do you approve the task changes in [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L36) through [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L39), especially the credential-status-page landing page and the "next MCP connection" freshness boundary?
+
+### Round 3 — specify (judge)
+
+## Round 3 — specify
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- H-1: Round 3 resolves the coordinator decision and tightens FR-009, but the spec still contains the old contradictory user-story wording. [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L12) says the post-setup page is a credential status page "confirming the connection is working," while [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L88) now explicitly says the page "MUST NOT claim connection status or validity." The builder round says Peter chose "source + masked token only" and that M-2 is resolved at [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L109) through [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L127), so this leftover sentence reintroduces the same ambiguity the round was meant to close. Update the User Story 1 narrative to match FR-009 and remove any claim that the root page confirms connection validity.
+
+### Medium
+- None
+
+### Low
+- L-1: The requirements checklist is now stale relative to the approved task/spec contract. [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md#L18) still describes FR-005 as only "GitHub auth OK but Copilot access denied," and [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md#L27) still says "next MCP invocation uses new token." But the current task/spec define four failure modes and "next MCP connection" at [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L37), [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L39), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L80) through [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L84), and [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L102). Update the checklist so it remains a real consistency gate instead of a stale artifact.
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the coordinator resolution in [status.json](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/status.json), the Round 3 responses in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), and the updated [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md).
+- Checked: Round 3 does resolve the prior escalation and medium findings in substance: the SDK-unavailable path now has an explicit Given/When/Then scenario, and FR-009 now forbids connection-status claims on the root page.
+- Checked: The only remaining high issue is the stale User Story 1 sentence at [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L12), which now contradicts FR-009.
+- Checked: The checklist drift is real in [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md#L18) and [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md#L27).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: The coordinator decision and the two Round 2 residual findings are resolved, but one cross-document contradiction and one stale checklist item remain.
+
+### Open Questions
+- None
+
+### [specify] Round 4 — judge
+
+## Round 4 — specify
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- None
+
+### Low
+- L-1: The spec artifacts themselves now look consistent, but the builder artifact still violates the required within-phase archival rule. [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L1), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L56), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L104), and [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L141) show four active `specify` rounds in one file, and [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) does not exist. The protocol says that before writing Round N where N >= 3, if the active file has 2 or more `## Round` headers, the agent MUST move rounds 1 through N-2 into the archive and leave only the back-reference plus recent rounds in the active file [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L134) through [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L141). By Round 4, `builder.md` should no longer contain Rounds 1-2. Fix by creating `builder-archive.md`, preserving the raw Round 1 and Round 2 content there, and trimming `builder.md` to a back-reference plus Rounds 3-4.
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md), Round 4 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), the final [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), and the updated [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md).
+- Checked: The Round 3 substantive issues are resolved. User Story 1 now says the credential status page shows source + masked token, which matches FR-009, and the checklist now reflects FR-005's four failure modes plus the approved "next MCP connection" wording.
+- Checked: `builder-archive.md` is still missing, while [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md) still contains four `## Round` sections. That violates the deterministic archival rule in [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L134) through [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L141).
+- Checked: The active judge artifact was compacted for this round by archiving Round 2 and leaving Round 3 onward in `judge.md`, so the judge-side context-management requirement is satisfied.
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: No substantive spec problems remain. The only remaining issue is builder-side context management for within-phase archival.
+
+### Open Questions
+- None
+
+### [specify] Round 5 — judge
+
+## Round 5 — specify
+
+### Verdict
+escalated
+
+### Blockers
+- B-1: Round 5 partially addresses the prior archival finding by creating [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md), but it still does not satisfy the exact within-phase archival rule for a Round 5 write. [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L3), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L40), and [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L74) show Rounds 3, 4, and 5 still active, while the protocol says that once archival is triggered the agent must move rounds 1 through N-2 to the archive and leave only rounds N-1 onward in the active file [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L134) through [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L139). For Round 5, that means Round 3 should also have been moved out of the active builder artifact. Because this is the second consecutive round on the same context-management issue and [status.json](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/status.json#L5) through [status.json](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/status.json#L6) show the task has now reached `max_rounds`, the loop must escalate rather than keep iterating [AGENTS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/AGENTS.md#L128), [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L247). Substantively, the spec itself now looks acceptable; the remaining question is whether Peter wants one more cleanup round for strict protocol compliance or wants to accept the specify artifacts as-is.
+
+### High
+- None
+
+### Medium
+- None
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md), and [status.json](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/status.json).
+- Checked: The substantive spec issues are now resolved. User Story 1 matches FR-009, the checklist matches FR-005/FR-009/FR-010 and SC-002, and I do not see remaining acceptance-criteria gaps in the spec itself.
+- Checked: The remaining issue is process-only: after the Round 5 write, the active builder artifact still retains Round 3, which is stricter than the "rounds N-1 onward" rule allows for N=5.
+- Checked: This is now the second consecutive judge round on the same archival point, and the task has reached `max_rounds`, so escalation is required by repo policy and protocol.
+- Checked: The active judge artifact was compacted for this round by archiving Round 3 and leaving Round 4 onward in `judge.md`, so judge-side context management remains compliant.
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: Round 4's substantive low finding is resolved. The only unresolved issue is whether Peter wants to enforce one more strict archival cleanup despite the round cap.
+
+### Open Questions
+- Peter: should Claude do one final protocol-cleanup pass to move Round 3 from [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md) into [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md), or do you want to accept the specify artifacts as sufficient now that the spec content itself is clean?
+
+## [design] Archived Rounds
+
+### Round 1 — design (judge)
+
+## Round 1 — design
+
+### Verdict
+needs_revision
+
+### Blockers
+- B-1 (AP-002): The design silently collapses FR-005's distinct `auth` and `permission` failure modes into a single `"auth"` path, which breaks the accepted contract for AC-3. [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L12), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L26), [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md#L46), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L44), and [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L35) all redefine the validator to emit only `format`, `auth`, and `sdk`, while [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L37) and [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L80) require distinct, user-actionable auth and permission errors. As written, a token that lacks `copilot_requests` would produce the same remediation as an expired or revoked token, so the design cannot satisfy the accepted setup/rotation behavior. Fix by redesigning the validation flow so it still yields distinct user-facing outcomes, or escalate to Peter if a deeper spike proves that impossible; do not silently weaken the accepted spec.
+
+### High
+- H-1: The MCP-side "no credential configured" behavior is still not designed, even though the spec requires a clear error for that case. [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L57), [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md#L86), and [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L38) only describe swapping `CredentialResolver.resolve()` into `_initialize_copilot()` and returning early when it yields `None`. But the current runtime path then falls through to [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py#L133), which raises "Copilot SDK is not available ... and GITHUB_TOKEN is set," and the builder explicitly leaves that file unchanged at [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L41). That is neither clear nor accurate for the "no credential source is available" case promised by [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L60). Add an explicit no-credential startup state/error contract for MCP tools and carry that through the plan so the later build can meet the accepted behavior.
+
+### Medium
+- None
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: fail
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the prior phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing the new design round.
+- Checked: Reviewed Round 1 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), all new design artifacts under [specs/002-credential-setup](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup), and the current runtime integration points in [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py), [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py), [main.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/main.py), [Dockerfile](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/Dockerfile), [docker-compose.yml](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/docker-compose.yml), and [requirements.txt](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/requirements.txt).
+- Checked: Builder-side phase compaction is correct for design; the active [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md) now contains only the new design round with a back-reference to specify history.
+- Checked: Judge-side phase compaction was required because the active file still started with `specify`; I archived the prior raw rounds and added the specify phase summary before writing this design round.
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). B-1 matches AP-002. No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: None.
+
+### Open Questions
+- None
+
+### Round 2 — design (judge)
+
+## Round 2 — design
+
+### Verdict
+needs_revision
+
+### Blockers
+- B-1 (AP-002): The new two-step validator still overstates what it can infer, so AC-3 / FR-005 is not actually satisfied yet. [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md#L44) explicitly notes that Copilot `403` responses can mean missing subscription as well as missing permissions, but the same artifact then redefines every post-`GET /user` `list_models()` failure as "missing `copilot_requests`" at [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md#L46), [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md#L50), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L53), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L54), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L42), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L55), and [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L87). That directly conflicts with the accepted contract that the permission bucket is specifically for missing `copilot_requests`, while other Copilot access restrictions are a separate possibility in the spec and research at [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L37) and [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L80). The same contract also maps any non-2xx `GET /user` response to expired/revoked auth failure at [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md#L49), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L53), and [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L43), which is broader than FR-005's auth bucket and would misdiagnose non-auth API failures. As designed, a user can still be told to rotate a valid token or add `copilot_requests` when the real problem is an upstream / policy / entitlement issue. Fix by tightening the classification contract: only true GitHub-auth failures should map to `auth`, non-auth GitHub API failures need an unavailable-style path, and post-auth `list_models()` failures cannot be labeled as missing `copilot_requests` unless the builder can point to a reliable distinguishing signal. If that signal does not exist, escalate to Peter instead of narrowing the accepted spec by inference.
+
+### High
+- None
+
+### Medium
+- None
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: fail
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the prior phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing the new design round.
+- Checked: Reviewed Round 2 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), the updated [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md), [plan.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/plan.md), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), and the current runtime integration points in [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py) and [copilot_client.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/copilot_client.py).
+- Checked: Official GitHub REST docs for `GET /user` list both `401` and `403` as possible responses for the authenticated-user endpoint, so the contract's "other non-2xx => expired/revoked" rule is too broad for an auth-only bucket. Source: https://docs.github.com/en/rest/users/users#get-the-authenticated-user
+- Checked: Judge-side context management remains compliant. The active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) still contains only the current phase and fewer than two prior design rounds before this write, so no archival step was required.
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). B-1 matches AP-002. No new judge-side anti-pattern entry is needed.
+- Corrections: Round 2 does resolve the prior no-credential design gap. The remaining issue is the validator's still-overclaimed error classification.
+
+### Open Questions
+- None
+
+### Round 4 — design (judge)
+
+## Round 4 — design
+
+### Verdict
+escalated
+
+### Blockers
+- B-1: Round 4 resolves the validator type mismatch and the builder-side archival cleanup, but the design still cannot satisfy the accepted permission contract without a coordinator decision. The accepted task/spec still define AC-3 / FR-005's permission bucket as specifically "missing `copilot_requests`" at [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L37), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L24), and [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L80), while the current design explicitly broadens that bucket to generic Copilot-access denial and keeps an inconclusive auth fallback at [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md#L46), [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md#L50), [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md#L52), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L53), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md#L54), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L64), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L68), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L106), and [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L107). The builder now states that mismatch directly and asks Peter to choose how FR-005 should change instead of silently redefining it at [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L152), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L160), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L170), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L173), and [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L176). That is the correct stopping point: further builder/judge iteration would just restate the same coordinator-owned scope decision.
+
+### High
+- None
+
+### Medium
+- None
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pending coordinator decision
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 4.
+- Checked: Reviewed Round 4 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), plus the current [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), and [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md).
+- Checked: Round 4 resolves M-1. The token-validator contract now carries `bool | None` consistently across the signature, branch descriptions, and orchestration at [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L57), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L64), and [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L83).
+- Checked: Builder-side context management for design is now compliant. The active [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L1) keeps only recent design rounds, and design Round 1 has been moved to [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md#L156).
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `design` rounds; I moved Round 2 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 3 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L134).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). No new judge-side anti-pattern entry is needed. The builder correctly escalated instead of silently narrowing the accepted contract.
+- Checked external sources: None needed. This is a repo-local scope decision.
+- Corrections: Round 4 resolves the prior M-1 and L-1 findings. The remaining issue is now coordinator-owned.
+
+### Open Questions
+- Peter: should FR-005 / AC-3 keep the stricter "missing `copilot_requests`" permission meaning, broaden to generic Copilot-access denial, or collapse auth + permission back into one failure bucket?
+
+### Round 5 — design (judge)
+
+## Round 5 — design
+
+### Verdict
+escalated
+
+### Blockers
+- B-1 (AP-002): Round 5 says Peter required all error messages to be verbose/chatty with URLs and remediation and claims that change was applied across all design artifacts, but the actual design still leaves the format and SDK buckets underspecified. [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L196), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L198), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L211), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L216), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L223), and [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L37) define the new contract as applying to each failure mode, yet [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L22) still uses the old terse format-error example with no URL or diagnostic steps, [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L25) still shows a one-line SDK error example, [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L27) and [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L32) still document terse format messages only, and [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L141) through [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L143) give the SDK bucket only a rebuild command rather than the URL-bearing/self-diagnosis guidance the round claims is now universal. [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L80) also weakens the rule to "specific URLs or steps," while [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L37) requires "specific URLs and remediation steps," so the artifacts do not even agree on the exact message contract. As written, AC-3 is still not fully specified for the format and SDK paths, so the design cannot be accepted. Because [status.json](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/status.json#L5) and [status.json](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/status.json#L6) show this is Round 5 of 5, the protocol requires escalation rather than another normal revision round [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L247).
+
+### High
+- None
+
+### Medium
+- None
+
+### Low
+- L-1: Builder-side within-phase archival regressed again in Round 5. The active [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L3), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L63), [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L136), and [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L192) show four active design rounds, but before writing Round 5 the protocol required the builder to archive rounds 1 through 3 and leave only rounds 4 onward in the active file [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L134), [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L138), and [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L139). If Peter allows a cleanup pass despite the round cap, Claude should archive design Rounds 2-3 before doing anything else.
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: fail
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 5.
+- Checked: Reviewed Round 5 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), plus the updated [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), [research.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/research.md), [data-model.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/data-model.md), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md), and [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md).
+- Checked: Round 5 resolves the earlier permission-scope escalation in substance. The remaining issue is narrower: the newly expanded message-format requirement was not propagated consistently to the format and SDK paths, and the task/spec/contracts now disagree on whether every message must include URLs plus steps or only URLs or steps.
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two design rounds; I moved Round 3 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 4 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L134).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). B-1 matches AP-002. No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: Round 5 materially improves the design, but AC-3 is still not fully closed on the written artifacts.
+
+### Open Questions
+- Peter: do you want to allow one final cleanup round to propagate the verbose-message requirement to the format and SDK paths and re-archive [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), or do you want to accept the current design as sufficient despite those remaining documentation gaps?
+
+### [design] Round 6 — judge
+
+## Round 6 — design
+
+### Verdict
+needs_revision
+
+### Blockers
+- B-1 (AP-002): Round 6 fixes the wording mismatch and the format-message gap, but the SDK failure path still does not satisfy the accepted "URLs and remediation steps" contract. [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md#L37), [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md#L18), and the builder's own resolution claim at [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L151) and [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L162) all say every failure mode now carries URL-bearing guidance, yet the actual SDK examples at [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L25), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md#L84), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L102), and [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md#L190) only provide shell commands and diagnostics, with no troubleshooting URL. As written, AC-3 is still not fully specified for the SDK bucket. Fix by adding a concrete URL to the SDK error examples/templates, or by getting Peter to explicitly exempt SDK errors from the URL requirement instead of leaving the contract half-applied.
+
+### High
+- None
+
+### Medium
+- None
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: fail
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 6.
+- Checked: Reviewed Round 6 in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), plus the current [task.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/task.md), [spec.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/spec.md), [token-validator.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/contracts/token-validator.md), and [requirements.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/checklists/requirements.md).
+- Checked: Round 6 does resolve the prior builder archival finding. The active [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L1) now keeps only recent design rounds, and the older design rounds are in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md).
+- Checked: Judge-side within-phase archival was required before this write because the active [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md) already had two `design` rounds; I moved Round 4 into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) and left Round 5 onward active per [PROTOCOL.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/PROTOCOL.md#L117).
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). B-1 matches AP-002. No new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: Round 6 closes the format-side documentation gap and the builder archival issue. The only remaining acceptance gap is the missing SDK troubleshooting URL.
+
+### Open Questions
+- None
+
+### [build] Round 1 — judge
+
+(needs_revision: H-1 broad exception catch in load(), M-1 hardcoded mask_token prefix. All 9 ACs pass.)
+
+### [build] Round 2 — judge
+
+(accepted: Both findings addressed. 481 tests pass. No new issues.)
+
+## [test] Archived Rounds
+
+### Round 1 — test (judge)
+
+## Round 1 — test
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- M-1 (AP-001): [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L69) marks AC-5 as verified by `TestPostSettingsRotate::test_valid_token_replaces_and_redirects`, but [test_web_routes.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_web_routes.py#L268) only proves the settings route validates, stores, and redirects. It does not verify the accepted FR-010 / AC-5 process-boundary behavior that a fresh MCP connection re-runs credential resolution and uses the rotated token. The accepted plan explicitly required MCP startup tests for this in [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L71), yet [test_mcp_server_config.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_server_config.py#L1) still only covers `_parse_timeout()`, and my local coverage run leaves [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py#L83) through [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py#L111) uncovered. That means `_initialize_copilot()` can regress in the no-credential path or the next-connection rotation path without failing the suite. Fix by adding direct MCP startup tests that cover: `resolve() -> None` sets `NoCredentialError` with all 3 remediation paths, `resolve() -> token` passes that token into `_copilot.start()`, and a fresh initialization after rotation picks up the newly stored token.
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: fail
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing the first `test` round.
+- Checked: Reviewed [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), the accepted MCP-test requirement in [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L71), the current MCP startup implementation in [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py#L83), the handler coverage in [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py), the route-level rotation test in [test_web_routes.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_web_routes.py#L268), and the current contents of [test_mcp_server_config.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_server_config.py#L1).
+- Checked: Ran `pytest --cov=server --cov-report=term-missing -q` locally. Result: 482 passed, 11 warnings, 94% total coverage. The builder's headline numbers are accurate.
+- Checked: The coverage report still leaves `server/mcp_server.py` lines 90-111 unexecuted, which matches the missing `_initialize_copilot()` verification described above.
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). This finding matches existing AP-001; no new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: None.
+
+### Open Questions
+- None
+
+### Round 2 — test (judge)
+
+## Round 2 — test
+
+### Verdict
+accepted
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- None
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md) before reviewing Round 2.
+- Checked: Reviewed the builder's Round 2 evidence in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), the accepted MCP-test requirement in [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L71), the startup implementation in [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py#L74), and the new direct `_initialize_copilot()` coverage in [test_mcp_server_config.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_server_config.py#L70).
+- Checked: [test_mcp_server_config.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_server_config.py#L93) now covers the three concrete behaviors required by M-1: `resolve() -> None` stores `NoCredentialError` with all remediation paths, `resolve() -> token` passes the resolved token into `_copilot.start()`, and a fresh `_initialize_copilot()` call after rotation picks up the new token while constructing a fresh resolver/store pair.
+- Checked: [test_mcp_handlers.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_handlers.py#L155) still maps `NoCredentialError` to `no_credential` for `start_review`, so the startup-error path does not fall through to `internal`.
+- Checked: Ran `pytest tests/test_mcp_server_config.py -q` locally. Result: 25 passed in 0.31s.
+- Checked: Ran `pytest tests/test_mcp_handlers.py -q` locally. Result: 22 passed in 0.32s.
+- Checked: Ran `pytest --cov=server --cov-report=term-missing -q` locally. Result: 494 passed, 11 warnings, 95% total coverage. [mcp_server.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/mcp_server.py#L83) is now 89% covered, and the previous `_initialize_copilot()` blind spot is gone from the miss list.
+- Checked: The remaining coverage misses in `server/mcp_server.py` are handler/error branches outside spec 002's MCP-credential boundary, so they do not block AC-5 or this phase outcome.
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). The prior AP-001 finding is resolved; no new anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: M-1 is resolved.
+
+### Open Questions
+- None

--- a/agent-loop/002-credential-setup/judge.md
+++ b/agent-loop/002-credential-setup/judge.md
@@ -1,0 +1,83 @@
+<!-- Phase history: specify (5 rounds, accepted via coordinator at round 6), design (8 rounds, accepted at round 8), plan (10 rounds, accepted at round 10), build (2 rounds, accepted at round 2), test (2 rounds, accepted at round 2) — see judge-archive.md -->
+
+## Round 1 — release
+
+### Verdict
+needs_revision
+
+### Blockers
+- None
+
+### High
+- H-1 (AP-001): [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L7) says spec 002 is complete, all 27 tasks were implemented via TDD, all 9 acceptance criteria were verified, and the branch is ready to merge, but the same round later states that Docker build/run validation was deferred to manual testing at [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L90). That leaves the release-only tasks at [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L116) and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L117) unclosed, so container-bound behaviors such as actual startup after the new Dockerfile/dependency changes, `/data` volume permissions/persistence, host-side `127.0.0.1` binding, and manual end-to-end AC evidence are still inferred from unit tests and static config. The AC table reinforces that gap: AC-8 is marked PASS from the compose file alone at [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L75), not from a daemon-backed run. Fix by replacing the limitation with actual T026/T027 evidence from a Docker host: `docker compose build --no-cache`, `docker compose up -d`, proof that `/data` exists with the expected permissions and persists across restart, proof that the host binding is localhost-only, and a manual AC verification record instead of test-name proxies.
+
+### Medium
+- None
+
+### Low
+- L-1: [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md#L7) also overstates the TDD completion claim for the resolver log-safety contract. [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L43) requires `tests/test_credential_resolver.py` to cover "logging source type without token value", and the runtime logging branches live at [credential_resolver.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/credential_resolver.py#L61), [credential_resolver.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/credential_resolver.py#L67), [credential_resolver.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/credential_resolver.py#L75), and [credential_resolver.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/credential_resolver.py#L78), but [tests/test_credential_resolver.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_credential_resolver.py#L1) still has no `caplog`/logging assertions. The implementation looks safe on inspection, but SC-003's "never expose tokens in logs" contract is not actually locked in by tests for the resolver path. Fix by adding explicit log assertions for each source/no-source branch and asserting the token substring never appears.
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md), plus the prior active `test` rounds before compacting them into [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md).
+- Checked: Reviewed the builder's release evidence in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md), the remaining release tasks in [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L114), [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L116), and [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md#L117), the resolver logging surface in [credential_resolver.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/credential_resolver.py#L61), and the current resolver test file at [tests/test_credential_resolver.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_credential_resolver.py#L1).
+- Checked: Ran `pytest --cov=server --cov-report=term-missing -q` locally. Result: 494 passed, 11 warnings, 95% total coverage. The builder's test-count and coverage headline are accurate.
+- Checked: Ran `docker --version` and `docker compose version` locally. Daemonless `docker compose config` confirms the static localhost port mapping, named `review-data` volume, and configured secret mount in [docker-compose.yml](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/docker-compose.yml#L1), but daemon-backed Docker checks needed for T026 were not executable here because access to the Docker socket is denied in this environment.
+- Checked: `tests/test_credential_resolver.py` still contains no `caplog` or logging assertions even though T008 names that coverage explicitly.
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). H-1 matches AP-001; no new judge-side anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: The builder's unit-test / coverage evidence is accurate. The release-completion claim is not yet substantiated.
+
+### Open Questions
+- None
+
+## Round 2 — release
+
+### Verdict
+accepted
+
+### Blockers
+- None
+
+### High
+- None
+
+### Medium
+- None
+
+### Low
+- None
+
+### Acceptance Check
+- AC-1: pass
+- AC-2: pass
+- AC-3: pass
+- AC-4: pass
+- AC-5: pass
+- AC-6: pass
+- AC-7: pass
+- AC-8: pass
+- AC-9: pass
+
+### Verification
+- Checked: Re-read the phase summaries in [builder-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder-archive.md) and [judge-archive.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge-archive.md), plus the active release rounds in [builder.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/builder.md) and [judge.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/002-credential-setup/judge.md).
+- Checked: Reviewed the changed release-phase artifacts backing the prior findings, including [server/web_routes.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/server/web_routes.py), [tests/test_credential_resolver.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_credential_resolver.py), [tests/test_mcp_server_config.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_mcp_server_config.py), [tests/test_web_routes.py](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/tests/test_web_routes.py), [Dockerfile](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/Dockerfile), [docker-compose.yml](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/docker-compose.yml), and the release tasks in [tasks.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/specs/002-credential-setup/tasks.md).
+- Checked: Ran `pytest --cov=server --cov-report=term-missing -q`. Result: 498 passed, 95% total coverage, 0 warnings.
+- Checked: Ran `docker --version`, `docker compose version`, and `docker compose config`. Static compose rendering confirms the localhost-only host binding, named `review-data` volume, and `/run/secrets/github_token` secret target described in the builder's release evidence.
+- Checked: Docker daemon-backed validation remains unavailable in this sandbox because access to `/Users/Peter_Petroczy/.docker/run/docker.sock` is denied, so I could not independently re-run T026/T027. I found no repo-local artifact that contradicts the builder's reported Docker build/run evidence.
+- Checked: [ANTIPATTERNS.md](/Users/Peter_Petroczy/Documents/Projects/Agent-in-a-Box/agent-loop/ANTIPATTERNS.md). The prior AP-001 issue is addressed; no new anti-pattern entry is needed.
+- Checked external sources: None needed. This review is repo-local.
+- Corrections: The resolver log-safety gap is now covered by direct assertions, and the Starlette template rendering path is updated consistently across all route handlers.
+
+### Open Questions
+- None

--- a/agent-loop/002-credential-setup/status.json
+++ b/agent-loop/002-credential-setup/status.json
@@ -1,0 +1,447 @@
+{
+  "task_id": "002-credential-setup",
+  "phase": "release",
+  "state": "accepted",
+  "round": 2,
+  "max_rounds": 20,
+  "builder": "claude",
+  "judge": "codex",
+  "verdict": "accepted",
+  "updated_at": "2026-03-24T14:27:25Z",
+  "history": [
+    {
+      "round": 1,
+      "phase": "specify",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-21T00:30:00Z"
+    },
+    {
+      "round": 1,
+      "phase": "specify",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-21T21:44:34Z"
+    },
+    {
+      "round": 2,
+      "phase": "specify",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-21T22:00:00Z"
+    },
+    {
+      "round": 2,
+      "phase": "specify",
+      "actor": "judge",
+      "verdict": "escalated",
+      "timestamp": "2026-03-21T22:10:00Z"
+    },
+    {
+      "round": 3,
+      "phase": "specify",
+      "actor": "coordinator",
+      "verdict": "resolved",
+      "timestamp": "2026-03-21T22:20:00Z"
+    },
+    {
+      "round": 3,
+      "phase": "specify",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-21T22:30:00Z"
+    },
+    {
+      "round": 3,
+      "phase": "specify",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-21T22:46:31Z"
+    },
+    {
+      "round": 4,
+      "phase": "specify",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T00:00:00Z"
+    },
+    {
+      "round": 4,
+      "phase": "specify",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T00:10:00Z"
+    },
+    {
+      "round": 5,
+      "phase": "specify",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T00:30:00Z"
+    },
+    {
+      "round": 5,
+      "phase": "specify",
+      "actor": "judge",
+      "verdict": "escalated",
+      "timestamp": "2026-03-22T00:40:00Z"
+    },
+    {
+      "round": 6,
+      "phase": "specify",
+      "actor": "coordinator",
+      "verdict": "accepted",
+      "timestamp": "2026-03-22T01:00:00Z"
+    },
+    {
+      "round": 1,
+      "phase": "design",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T02:30:00Z"
+    },
+    {
+      "round": 1,
+      "phase": "design",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T02:40:00Z"
+    },
+    {
+      "round": 2,
+      "phase": "design",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T15:30:00Z"
+    },
+    {
+      "round": 2,
+      "phase": "design",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T15:40:00Z"
+    },
+    {
+      "round": 3,
+      "phase": "design",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T16:00:00Z"
+    },
+    {
+      "round": 3,
+      "phase": "design",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T16:10:00Z"
+    },
+    {
+      "round": 4,
+      "phase": "design",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T17:00:00Z"
+    },
+    {
+      "round": 4,
+      "phase": "design",
+      "actor": "judge",
+      "verdict": "escalated",
+      "timestamp": "2026-03-22T17:10:00Z"
+    },
+    {
+      "round": 5,
+      "phase": "design",
+      "actor": "coordinator",
+      "verdict": "resolved",
+      "timestamp": "2026-03-22T17:30:00Z"
+    },
+    {
+      "round": 5,
+      "phase": "design",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T18:00:00Z"
+    },
+    {
+      "round": 5,
+      "phase": "design",
+      "actor": "judge",
+      "verdict": "escalated",
+      "timestamp": "2026-03-22T18:10:00Z"
+    },
+    {
+      "round": 6,
+      "phase": "design",
+      "actor": "coordinator",
+      "verdict": "resolved",
+      "timestamp": "2026-03-22T19:00:00Z"
+    },
+    {
+      "round": 6,
+      "phase": "design",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T19:30:00Z"
+    },
+    {
+      "round": 6,
+      "phase": "design",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T19:51:15Z"
+    },
+    {
+      "round": 7,
+      "phase": "design",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T20:00:00Z"
+    },
+    {
+      "round": 7,
+      "phase": "design",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T20:10:00Z"
+    },
+    {
+      "round": 8,
+      "phase": "design",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T20:20:00Z"
+    },
+    {
+      "round": 8,
+      "phase": "design",
+      "actor": "judge",
+      "verdict": "accepted",
+      "timestamp": "2026-03-22T20:30:00Z"
+    },
+    {
+      "round": 1,
+      "phase": "plan",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T21:15:00Z"
+    },
+    {
+      "round": 1,
+      "phase": "plan",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T21:30:00Z"
+    },
+    {
+      "round": 2,
+      "phase": "plan",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T22:00:00Z"
+    },
+    {
+      "round": 2,
+      "phase": "plan",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T01:47:09Z"
+    },
+    {
+      "round": 3,
+      "phase": "plan",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T02:15:00Z"
+    },
+    {
+      "round": 3,
+      "phase": "plan",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T01:51:47Z"
+    },
+    {
+      "round": 4,
+      "phase": "plan",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T02:30:00Z"
+    },
+    {
+      "round": 4,
+      "phase": "plan",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T02:02:07Z"
+    },
+    {
+      "round": 5,
+      "phase": "plan",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T03:00:00Z"
+    },
+    {
+      "round": 5,
+      "phase": "plan",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T16:30:07Z"
+    },
+    {
+      "round": 6,
+      "phase": "plan",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T17:00:00Z"
+    },
+    {
+      "round": 6,
+      "phase": "plan",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T17:10:00Z"
+    },
+    {
+      "round": 7,
+      "phase": "plan",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T17:30:00Z"
+    },
+    {
+      "round": 7,
+      "phase": "plan",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T17:45:00Z"
+    },
+    {
+      "round": 8,
+      "phase": "plan",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T22:30:00Z"
+    },
+    {
+      "round": 8,
+      "phase": "plan",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T22:45:00Z"
+    },
+    {
+      "round": 9,
+      "phase": "plan",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T23:00:00Z"
+    },
+    {
+      "round": 9,
+      "phase": "plan",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-22T23:10:00Z"
+    },
+    {
+      "round": 10,
+      "phase": "plan",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T23:30:00Z"
+    },
+    {
+      "round": 10,
+      "phase": "plan",
+      "actor": "judge",
+      "verdict": "accepted",
+      "timestamp": "2026-03-22T23:45:00Z"
+    },
+    {
+      "round": 1,
+      "phase": "build",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-22T13:00:00Z"
+    },
+    {
+      "round": 1,
+      "phase": "build",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-23T01:08:39Z"
+    },
+    {
+      "round": 2,
+      "phase": "build",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-23T02:00:00Z"
+    },
+    {
+      "round": 2,
+      "phase": "build",
+      "actor": "judge",
+      "verdict": "accepted",
+      "timestamp": "2026-03-23T09:09:59Z"
+    },
+    {
+      "round": 1,
+      "phase": "test",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-23T10:00:00Z"
+    },
+    {
+      "round": 1,
+      "phase": "test",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-23T15:47:20Z"
+    },
+    {
+      "round": 2,
+      "phase": "test",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-23T16:30:00Z"
+    },
+    {
+      "round": 2,
+      "phase": "test",
+      "actor": "judge",
+      "verdict": "accepted",
+      "timestamp": "2026-03-23T21:13:43Z"
+    },
+    {
+      "round": 1,
+      "phase": "release",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-24T00:00:00Z"
+    },
+    {
+      "round": 1,
+      "phase": "release",
+      "actor": "judge",
+      "verdict": "needs_revision",
+      "timestamp": "2026-03-23T23:44:01Z"
+    },
+    {
+      "round": 2,
+      "phase": "release",
+      "actor": "builder",
+      "verdict": null,
+      "timestamp": "2026-03-24T14:00:00Z"
+    },
+    {
+      "round": 2,
+      "phase": "release",
+      "actor": "judge",
+      "verdict": "accepted",
+      "timestamp": "2026-03-24T14:27:25Z"
+    }
+  ]
+}

--- a/agent-loop/002-credential-setup/task.md
+++ b/agent-loop/002-credential-setup/task.md
@@ -1,0 +1,51 @@
+# Task: 002 — Credential Setup & Management
+
+## Goal
+
+Implement secure credential management for the AgentinaBox review server so users can configure, store, rotate, and resolve GitHub PATs through multiple sources (Docker secrets, environment variables, and encrypted persistent storage), with a web-based setup wizard for first-time configuration.
+
+## Scope
+
+**In scope** (from `specs/002-credential-setup/spec.md`):
+- Fernet-encrypted credential storage in Docker named volume (`/data/`)
+- Three-source credential resolution: Docker secret > env var > stored credential
+- Fine-grained PAT format validation (reject classic PATs)
+- Token validation via Copilot SDK `list_models()` call
+- Web setup wizard at `localhost:8080` for first-time configuration
+- Settings page for token viewing (masked) and rotation
+- Localhost-only web UI binding
+- Token never exposed in logs, responses, or UI
+
+**Out of scope**:
+- Dashboard UI (spec 003)
+- Model configuration / selection UI (spec 005)
+- Fallback backends (spec 006)
+- External KMS or Vault integration
+- Multi-user / RBAC
+
+## Constraints
+
+- Constitution: project-agnostic, no host volume mounts, security boundary, TDD, YAGNI
+- Server-rendered Jinja2 templates, monospace dark theme, single CSS file
+- Python 3.11+, FastAPI, Docker
+- MCP server and web server are separate processes (no shared memory)
+
+## Acceptance Criteria
+
+- AC-1: Fresh container with no credentials → web setup wizard is displayed at `localhost:8080`
+- AC-2: User pastes valid fine-grained PAT → server validates via Copilot SDK, encrypts, stores, redirects to credential status page
+- AC-3: User pastes invalid token → distinct, verbose error messages for each failure mode: format error (wrong prefix), auth error (expired/revoked), permission error (cannot access Copilot — lists causes: missing copilot_requests, no subscription, org policy), SDK error (unavailable). Messages include specific URLs and remediation steps.
+- AC-4: Container started with `GITHUB_TOKEN` env var or Docker secret → credential status page displayed (setup wizard skipped)
+- AC-5: Stored token can be rotated via Settings page without container restart; next MCP connection uses new token
+- AC-6: Credential sources follow priority: Docker secret > env var > stored credential
+- AC-7: Token is never visible in plaintext in logs, API responses, or web UI
+- AC-8: Web UI is only accessible via localhost (127.0.0.1 binding)
+- AC-9: Encryption key loss → treated as no credential, setup wizard shown
+
+## Spec Path
+
+`specs/002-credential-setup/spec.md`
+
+## Phase
+
+`specify`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,26 @@ services:
   review-server:
     build: .
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     environment:
       - GITHUB_TOKEN=${GITHUB_TOKEN}
       # Copilot SDK call timeouts in seconds (defaults: 120 for review, 60 for discuss)
       - REVIEW_TIMEOUT=${REVIEW_TIMEOUT:-120}
       - DISCUSS_TIMEOUT=${DISCUSS_TIMEOUT:-60}
+    volumes:
+      - review-data:/data
+    secrets:
+      - github_token
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
       interval: 30s
       timeout: 5s
       start_period: 10s
       retries: 3
+
+secrets:
+  github_token:
+    file: ${GITHUB_TOKEN_FILE:-/dev/null}
+
+volumes:
+  review-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,16 @@
 services:
   review-server:
     build: .
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     ports:
       - "127.0.0.1:8080:8080"
     environment:
+      # Convenience fallback — Docker secrets (below) are preferred.
+      # Env vars are visible via `docker inspect`.
       - GITHUB_TOKEN=${GITHUB_TOKEN}
       # Copilot SDK call timeouts in seconds (defaults: 120 for review, 60 for discuss)
       - REVIEW_TIMEOUT=${REVIEW_TIMEOUT:-120}
@@ -21,6 +28,8 @@ services:
 
 secrets:
   github_token:
+    # Falls back to /dev/null (empty) when GITHUB_TOKEN_FILE is unset.
+    # The resolver will use env var or stored credential instead.
     file: ${GITHUB_TOKEN_FILE:-/dev/null}
 
 volumes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "jinja2>=3.1.0",
     "github-copilot-sdk>=0.1.0",
     "json-repair>=0.50.0",
+    "cryptography>=44.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pydantic>=2.12.0
 jinja2>=3.1.0
 github-copilot-sdk>=0.1.0
 json-repair>=0.50.0
+cryptography>=44.0.0
 
 # Dev dependencies
 pytest>=8.0.0

--- a/server/copilot_client.py
+++ b/server/copilot_client.py
@@ -103,6 +103,7 @@ class CopilotReviewClient:
         self._sessions.clear()
         self._connected = False
         self._startup_error = None
+        self._github_token = None
         if self._sdk_client is not None:
             try:
                 if hasattr(self._sdk_client, "stop"):
@@ -233,7 +234,15 @@ class CopilotReviewClient:
         except ImportError:
             self._sdk_client = None
             self._available_models = []
+            self._startup_error = CopilotUnavailableError(
+                "github-copilot-sdk is not installed"
+            )
         except Exception as e:
+            if self._sdk_client is not None:
+                try:
+                    await self._sdk_client.stop()
+                except Exception:
+                    pass
             self._sdk_client = None
             self._available_models = []
             err_str = str(e).lower()

--- a/server/copilot_client.py
+++ b/server/copilot_client.py
@@ -108,12 +108,12 @@ class CopilotReviewClient:
                 if hasattr(self._sdk_client, "stop"):
                     await self._sdk_client.stop()
             except Exception as e:
-                logger.warning("SDK client stop failed: %s, attempting force_stop", e)
+                logger.warning("SDK client stop failed (%s), attempting force_stop", type(e).__name__)
                 try:
                     if hasattr(self._sdk_client, "force_stop"):
                         await self._sdk_client.force_stop()
                 except Exception as e2:
-                    logger.error("SDK client force_stop also failed: %s", e2)
+                    logger.error("SDK client force_stop also failed (%s)", type(e2).__name__)
         self._sdk_client = None
 
     async def get_available_models(self) -> list[dict[str, Any]]:

--- a/server/copilot_client.py
+++ b/server/copilot_client.py
@@ -11,8 +11,11 @@ with `github-copilot-sdk` installed.
 from __future__ import annotations
 
 import asyncio
+import logging
 import uuid
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 # --- Error hierarchy per copilot-client.md ---
@@ -48,6 +51,12 @@ class CopilotUnavailableError(CopilotError):
     retryable = False
 
 
+class NoCredentialError(CopilotError):
+    """No credential configured — terminal."""
+
+    retryable = False
+
+
 # Model preference order per research.md Decision 4
 MODEL_PREFERENCE = [
     "gpt-4o",
@@ -74,6 +83,10 @@ class CopilotReviewClient:
         self._github_token: str | None = None
         self._startup_error: CopilotError | None = None
 
+    def set_startup_error(self, error: "CopilotError") -> None:
+        """Set a startup error for deferred raising on first tool call."""
+        self._startup_error = error
+
     async def start(self, github_token: str) -> None:
         """Initialize CopilotClient, start CLI process, select model."""
         if not github_token:
@@ -94,9 +107,13 @@ class CopilotReviewClient:
             try:
                 if hasattr(self._sdk_client, "stop"):
                     await self._sdk_client.stop()
-            except Exception:
-                if hasattr(self._sdk_client, "force_stop"):
-                    await self._sdk_client.force_stop()
+            except Exception as e:
+                logger.warning("SDK client stop failed: %s, attempting force_stop", e)
+                try:
+                    if hasattr(self._sdk_client, "force_stop"):
+                        await self._sdk_client.force_stop()
+                except Exception as e2:
+                    logger.error("SDK client force_stop also failed: %s", e2)
         self._sdk_client = None
 
     async def get_available_models(self) -> list[dict[str, Any]]:

--- a/server/credential_resolver.py
+++ b/server/credential_resolver.py
@@ -1,0 +1,109 @@
+"""Multi-source credential resolution — T009.
+
+Resolves the active credential from the highest-priority available source.
+Per contract: specs/002-credential-setup/contracts/credential-resolver.md
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from enum import Enum
+
+from server.credential_store import CredentialStore
+
+logger = logging.getLogger(__name__)
+
+
+class CredentialSource(str, Enum):
+    DOCKER_SECRET = "docker_secret"
+    ENV_VAR = "env_var"
+    STORED = "stored"
+    NONE = "none"
+
+
+@dataclass(frozen=True)
+class ResolvedCredential:
+    """In-memory only. Never persisted."""
+    token: str
+    source: CredentialSource
+
+    def __post_init__(self):
+        if not self.token:
+            raise ValueError("ResolvedCredential requires a non-empty token")
+
+    def __repr__(self) -> str:
+        """Mask token in repr to prevent accidental exposure in logs/tracebacks."""
+        return f"ResolvedCredential(token='***masked***', source={self.source!r})"
+
+
+class CredentialResolver:
+    """Resolves credentials from multiple sources in priority order."""
+
+    def __init__(
+        self,
+        store: CredentialStore,
+        docker_secret_path: str = "/run/secrets/github_token",
+    ) -> None:
+        self._store = store
+        self._docker_secret_path = docker_secret_path
+
+    def resolve(self) -> ResolvedCredential | None:
+        """Resolve credential from highest-priority source.
+
+        Priority order (FR-002):
+          1. Docker secret (file at /run/secrets/github_token)
+          2. Environment variable (GITHUB_TOKEN)
+          3. Stored credential (decrypted from /data/)
+
+        Returns None if no source provides a credential.
+        """
+        # 1. Docker secret
+        token = self._read_docker_secret()
+        if token:
+            logger.info("Credential resolved from docker_secret")
+            return ResolvedCredential(token=token, source=CredentialSource.DOCKER_SECRET)
+
+        # 2. Environment variable
+        token = os.environ.get("GITHUB_TOKEN", "").strip()
+        if token:
+            logger.info("Credential resolved from env_var")
+            return ResolvedCredential(token=token, source=CredentialSource.ENV_VAR)
+
+        # 3. Stored credential
+        try:
+            token = self._store.load()
+        except OSError as e:
+            logger.warning("Failed to read stored credential: %s", type(e).__name__)
+            token = None
+        if token:
+            token = token.strip()
+            if token:
+                logger.info("Credential resolved from stored")
+                return ResolvedCredential(token=token, source=CredentialSource.STORED)
+
+        logger.info("No credential source available")
+        return None
+
+    def get_source(self) -> CredentialSource:
+        """Return the source type without exposing the token."""
+        result = self.resolve()
+        if result is None:
+            return CredentialSource.NONE
+        return result.source
+
+    def _read_docker_secret(self) -> str | None:
+        """Read Docker secret file, strip whitespace. Returns None if missing/empty."""
+        try:
+            with open(self._docker_secret_path) as f:
+                token = f.read().strip()
+            return token if token else None
+        except FileNotFoundError:
+            return None
+        except OSError as e:
+            logger.warning(
+                "Docker secret at %s exists but could not be read: %s",
+                self._docker_secret_path, e,
+            )
+            return None

--- a/server/credential_resolver.py
+++ b/server/credential_resolver.py
@@ -88,10 +88,13 @@ class CredentialResolver:
 
     def get_source(self) -> CredentialSource:
         """Return the source type without exposing the token."""
-        result = self.resolve()
-        if result is None:
-            return CredentialSource.NONE
-        return result.source
+        if self._read_docker_secret():
+            return CredentialSource.DOCKER_SECRET
+        if os.environ.get("GITHUB_TOKEN", "").strip():
+            return CredentialSource.ENV_VAR
+        if self._store.has_stored_credential():
+            return CredentialSource.STORED
+        return CredentialSource.NONE
 
     def _read_docker_secret(self) -> str | None:
         """Read Docker secret file, strip whitespace. Returns None if missing/empty."""

--- a/server/credential_store.py
+++ b/server/credential_store.py
@@ -133,8 +133,9 @@ class CredentialStore:
                 fh.flush()
                 os.fsync(fh.fileno())
             os.replace(tmp_meta, self._meta_path)
-        except OSError:
+        except OSError as e:
             # Metadata freshness is non-critical; log and continue
+            logger.warning("Failed to update last_validated_at metadata: %s", type(e).__name__)
             try:
                 os.unlink(tmp_meta)
             except FileNotFoundError:

--- a/server/credential_store.py
+++ b/server/credential_store.py
@@ -121,10 +121,10 @@ class CredentialStore:
         # Atomic write with restrictive permissions
         tmp_key = self._key_path + ".tmp"
         fd = os.open(tmp_key, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        try:
-            os.write(fd, key)
-        finally:
-            os.close(fd)
+        with os.fdopen(fd, "wb", closefd=True) as fh:
+            fh.write(key)
+            fh.flush()
+            os.fsync(fh.fileno())
         os.replace(tmp_key, self._key_path)
         # Ensure final file has correct permissions
         os.chmod(self._key_path, stat.S_IRUSR | stat.S_IWUSR)

--- a/server/credential_store.py
+++ b/server/credential_store.py
@@ -1,0 +1,142 @@
+"""Fernet-encrypted credential storage — T007.
+
+Manages encrypted credential persistence in the Docker named volume (/data/).
+Per contract: specs/002-credential-setup/contracts/credential-store.md
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from cryptography.fernet import Fernet, InvalidToken
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CredentialMetadata:
+    created_at: datetime
+    last_validated_at: datetime
+
+
+class CredentialStore:
+    """Manages encrypted credential storage in /data/."""
+
+    def __init__(self, data_dir: str = "/data") -> None:
+        self._data_dir = data_dir
+        self._key_path = os.path.join(data_dir, ".fernet_key")
+        self._enc_path = os.path.join(data_dir, "credentials.enc")
+        self._meta_path = os.path.join(data_dir, "credential_meta.json")
+
+    def store(self, token: str) -> None:
+        """Encrypt and persist a token. Creates Fernet key on first use."""
+        key = self._get_or_create_key()
+        f = Fernet(key)
+        encrypted = f.encrypt(token.encode("utf-8"))
+
+        # Atomic write for credentials.enc
+        tmp_enc = self._enc_path + ".tmp"
+        with open(tmp_enc, "wb") as fh:
+            fh.write(encrypted)
+        os.replace(tmp_enc, self._enc_path)
+
+        # Write metadata
+        now = datetime.now(timezone.utc).isoformat()
+        existing_meta = self._read_meta_dict()
+        meta = {
+            "created_at": existing_meta.get("created_at", now),
+            "last_validated_at": now,
+        }
+        tmp_meta = self._meta_path + ".tmp"
+        with open(tmp_meta, "w") as fh:
+            json.dump(meta, fh)
+        os.replace(tmp_meta, self._meta_path)
+
+    def load(self) -> str | None:
+        """Load and decrypt the stored token. Returns None if unavailable."""
+        if not os.path.exists(self._enc_path):
+            return None
+        if not os.path.exists(self._key_path):
+            logger.warning("Fernet key missing but credentials.enc exists — treating as no credential")
+            return None
+        try:
+            with open(self._key_path, "rb") as fh:
+                key = fh.read()
+            f = Fernet(key)
+            with open(self._enc_path, "rb") as fh:
+                encrypted = fh.read()
+            return f.decrypt(encrypted).decode("utf-8")
+        except (InvalidToken, ValueError) as e:
+            logger.warning("Failed to decrypt credential: %s", type(e).__name__)
+            return None
+
+    def delete(self) -> None:
+        """Remove stored credential files. Does NOT remove .fernet_key."""
+        for path in (self._enc_path, self._meta_path):
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+
+    def get_metadata(self) -> CredentialMetadata | None:
+        """Read credential_meta.json. Returns None if file doesn't exist or is malformed."""
+        meta = self._read_meta_dict()
+        if not meta:
+            return None
+        try:
+            return CredentialMetadata(
+                created_at=datetime.fromisoformat(meta["created_at"]),
+                last_validated_at=datetime.fromisoformat(meta["last_validated_at"]),
+            )
+        except (KeyError, ValueError, TypeError) as e:
+            logger.warning("credential_meta.json has malformed data (%s) — returning None", type(e).__name__)
+            return None
+
+    def update_last_validated(self) -> None:
+        """Update last_validated_at in credential_meta.json to now."""
+        meta = self._read_meta_dict()
+        if not meta:
+            return
+        meta["last_validated_at"] = datetime.now(timezone.utc).isoformat()
+        tmp_meta = self._meta_path + ".tmp"
+        with open(tmp_meta, "w") as fh:
+            json.dump(meta, fh)
+        os.replace(tmp_meta, self._meta_path)
+
+    def has_stored_credential(self) -> bool:
+        """Check if credentials.enc exists (without decrypting)."""
+        return os.path.exists(self._enc_path)
+
+    def _get_or_create_key(self) -> bytes:
+        """Get existing Fernet key or generate a new one."""
+        if os.path.exists(self._key_path):
+            with open(self._key_path, "rb") as fh:
+                return fh.read()
+        key = Fernet.generate_key()
+        # Atomic write with restrictive permissions
+        tmp_key = self._key_path + ".tmp"
+        fd = os.open(tmp_key, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, key)
+        finally:
+            os.close(fd)
+        os.replace(tmp_key, self._key_path)
+        # Ensure final file has correct permissions
+        os.chmod(self._key_path, stat.S_IRUSR | stat.S_IWUSR)
+        return key
+
+    def _read_meta_dict(self) -> dict:
+        """Read credential_meta.json as dict. Returns {} if missing or corrupted."""
+        if not os.path.exists(self._meta_path):
+            return {}
+        try:
+            with open(self._meta_path) as fh:
+                return json.load(fh)
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.warning("credential_meta.json is corrupted (%s) — treating as empty", type(e).__name__)
+            return {}

--- a/server/credential_store.py
+++ b/server/credential_store.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class CredentialMetadata:
     created_at: datetime
-    last_validated_at: datetime
+    last_validated_at: datetime | None
 
 
 class CredentialStore:
@@ -33,29 +33,50 @@ class CredentialStore:
         self._enc_path = os.path.join(data_dir, "credentials.enc")
         self._meta_path = os.path.join(data_dir, "credential_meta.json")
 
+    def _ensure_data_dir(self) -> None:
+        """Raise if the data directory does not exist."""
+        if not os.path.isdir(self._data_dir):
+            raise FileNotFoundError(
+                f"Data directory does not exist: {self._data_dir}. "
+                f"Ensure the Docker volume is mounted."
+            )
+
     def store(self, token: str) -> None:
-        """Encrypt and persist a token. Creates Fernet key on first use."""
+        """Encrypt and persist a GitHub PAT, then write metadata."""
+        self._ensure_data_dir()
         key = self._get_or_create_key()
         f = Fernet(key)
-        encrypted = f.encrypt(token.encode("utf-8"))
-
-        # Atomic write for credentials.enc
+        encrypted = f.encrypt(token.encode())
         tmp_enc = self._enc_path + ".tmp"
-        with open(tmp_enc, "wb") as fh:
-            fh.write(encrypted)
-        os.replace(tmp_enc, self._enc_path)
-
-        # Write metadata
-        now = datetime.now(timezone.utc).isoformat()
-        existing_meta = self._read_meta_dict()
-        meta = {
-            "created_at": existing_meta.get("created_at", now),
-            "last_validated_at": now,
-        }
         tmp_meta = self._meta_path + ".tmp"
-        with open(tmp_meta, "w") as fh:
-            json.dump(meta, fh)
-        os.replace(tmp_meta, self._meta_path)
+        try:
+            # Write encrypted credential
+            fd = os.open(tmp_enc, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "wb", closefd=True) as fh:
+                fh.write(encrypted)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_enc, self._enc_path)
+            # Write metadata
+            existing = self._read_meta_dict()
+            now = datetime.now(timezone.utc).isoformat()
+            meta = {
+                "created_at": existing.get("created_at", now),
+                "last_validated_at": existing.get("last_validated_at"),
+            }
+            fd = os.open(tmp_meta, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w", closefd=True) as fh:
+                json.dump(meta, fh)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_meta, self._meta_path)
+        finally:
+            # Clean up orphaned temp files on any failure
+            for tmp in (tmp_enc, tmp_meta):
+                try:
+                    os.unlink(tmp)
+                except FileNotFoundError:
+                    pass
 
     def load(self) -> str | None:
         """Load and decrypt the stored token. Returns None if unavailable."""
@@ -71,7 +92,7 @@ class CredentialStore:
             with open(self._enc_path, "rb") as fh:
                 encrypted = fh.read()
             return f.decrypt(encrypted).decode("utf-8")
-        except (InvalidToken, ValueError) as e:
+        except (InvalidToken, ValueError, FileNotFoundError) as e:
             logger.warning("Failed to decrypt credential: %s", type(e).__name__)
             return None
 
@@ -89,24 +110,35 @@ class CredentialStore:
         if not meta:
             return None
         try:
+            raw_validated = meta.get("last_validated_at")
             return CredentialMetadata(
                 created_at=datetime.fromisoformat(meta["created_at"]),
-                last_validated_at=datetime.fromisoformat(meta["last_validated_at"]),
+                last_validated_at=datetime.fromisoformat(raw_validated) if raw_validated else None,
             )
         except (KeyError, ValueError, TypeError) as e:
             logger.warning("credential_meta.json has malformed data (%s) — returning None", type(e).__name__)
             return None
 
     def update_last_validated(self) -> None:
-        """Update last_validated_at in credential_meta.json to now."""
+        """Update the last_validated_at timestamp in metadata."""
         meta = self._read_meta_dict()
         if not meta:
             return
         meta["last_validated_at"] = datetime.now(timezone.utc).isoformat()
         tmp_meta = self._meta_path + ".tmp"
-        with open(tmp_meta, "w") as fh:
-            json.dump(meta, fh)
-        os.replace(tmp_meta, self._meta_path)
+        try:
+            fd = os.open(tmp_meta, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w", closefd=True) as fh:
+                json.dump(meta, fh)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_meta, self._meta_path)
+        except OSError:
+            # Metadata freshness is non-critical; log and continue
+            try:
+                os.unlink(tmp_meta)
+            except FileNotFoundError:
+                pass
 
     def has_stored_credential(self) -> bool:
         """Check if credentials.enc exists (without decrypting)."""

--- a/server/main.py
+++ b/server/main.py
@@ -1,15 +1,41 @@
-"""FastAPI app — T023.
+"""FastAPI app — T023 + T016.
 
-Minimal FastAPI app with health check endpoint.
+FastAPI app with health check, static files, templates, and credential management routes.
 Container CMD target: uvicorn server.main:app --host 0.0.0.0 --port 8080
-Per plan.md: health endpoint only for MVP. Web dashboard routes added in spec 003.
 """
 
 from __future__ import annotations
 
+import os
+
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from server.copilot_client import CopilotReviewClient
+from server.credential_resolver import CredentialResolver
+from server.credential_store import CredentialStore
+from server.token_validator import TokenValidator
+from server.web_routes import create_router
 
 app = FastAPI(title="AgentinaBox", version="0.1.0")
+
+# --- Directories ---
+_BASE_DIR = os.path.dirname(__file__)
+_TEMPLATES_DIR = os.path.join(_BASE_DIR, "templates")
+_STATIC_DIR = os.path.join(_BASE_DIR, "static")
+
+# --- Shared dependencies ---
+templates = Jinja2Templates(directory=_TEMPLATES_DIR)
+store = CredentialStore()
+resolver = CredentialResolver(store=store)
+validator = TokenValidator(copilot_client_factory=CopilotReviewClient)
+
+# --- Mount static files ---
+app.mount("/static", StaticFiles(directory=_STATIC_DIR), name="static")
+
+# --- Include credential management routes ---
+app.include_router(create_router(templates=templates, store=store, resolver=resolver, validator=validator))
 
 
 @app.get("/health")

--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -15,12 +15,15 @@ from mcp.server.fastmcp import FastMCP
 
 from server.copilot_client import (
     CopilotAuthError,
+    CopilotError,
     CopilotRateLimitError,
     CopilotReviewClient,
     CopilotTimeoutError,
     CopilotUnavailableError,
     NoCredentialError,
 )
+from server.credential_resolver import CredentialResolver
+from server.credential_store import CredentialStore
 from server.denylist import ContentDenylist
 from server.models import (
     DiscussRequest,
@@ -87,9 +90,6 @@ async def _initialize_copilot():
     If no credential is available, stores a NoCredentialError so tools return a
     clear error. If the SDK is unavailable, the server still starts.
     """
-    from server.credential_store import CredentialStore
-    from server.credential_resolver import CredentialResolver
-
     resolver = CredentialResolver(store=CredentialStore())
     try:
         resolved = resolver.resolve()
@@ -110,7 +110,6 @@ async def _initialize_copilot():
     try:
         await _copilot.start(github_token=token)
     except Exception as e:
-        from server.copilot_client import CopilotError
         if isinstance(e, CopilotError):
             _copilot.set_startup_error(e)
         else:

--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -19,6 +19,7 @@ from server.copilot_client import (
     CopilotReviewClient,
     CopilotTimeoutError,
     CopilotUnavailableError,
+    NoCredentialError,
 )
 from server.denylist import ContentDenylist
 from server.models import (
@@ -82,23 +83,41 @@ _engine = ReviewEngine(
 async def _initialize_copilot():
     """Initialize Copilot client on startup.
 
-    If GITHUB_TOKEN is missing or SDK is unavailable, the server still starts.
-    Tools will return clear errors when called without a working Copilot backend.
+    Resolves credentials via CredentialResolver (Docker secret > env var > stored).
+    If no credential is available, stores a NoCredentialError so tools return a
+    clear error. If the SDK is unavailable, the server still starts.
     """
-    token = os.environ.get("GITHUB_TOKEN", "")
-    if not token:
+    from server.credential_store import CredentialStore
+    from server.credential_resolver import CredentialResolver
+
+    resolver = CredentialResolver(store=CredentialStore())
+    try:
+        resolved = resolver.resolve()
+    except OSError as e:
+        logger.error("Credential resolver failed: %s", e)
+        _copilot.set_startup_error(CopilotUnavailableError(
+            f"Failed to resolve credentials: {type(e).__name__}: {e}"
+        ))
         return
+    if resolved is None:
+        _copilot.set_startup_error(NoCredentialError(
+            "No credential configured. Set up a token at localhost:8080, "
+            "provide GITHUB_TOKEN env var, or mount a Docker secret at "
+            "/run/secrets/github_token."
+        ))
+        return
+    token = resolved.token
     try:
         await _copilot.start(github_token=token)
-        if _copilot.is_connected:
-            await _copilot.select_model()
     except Exception as e:
-        # Store the error so tools can re-raise it with correct classification
         from server.copilot_client import CopilotError
         if isinstance(e, CopilotError):
-            _copilot._startup_error = e
-        # Non-CopilotError exceptions (e.g. unexpected crashes) leave the client
-        # in uninitialized state; create_review_session will raise CopilotUnavailableError
+            _copilot.set_startup_error(e)
+        else:
+            logger.error("Unexpected error during Copilot initialization: %s", e, exc_info=True)
+            _copilot.set_startup_error(CopilotUnavailableError(
+                f"Copilot initialization failed unexpectedly: {type(e).__name__}: {e}"
+            ))
 
 
 @asynccontextmanager
@@ -166,6 +185,8 @@ async def start_review(
         if "idempotency_conflict" in msg:
             return {"error": "idempotency_conflict", "message": msg, "retryable": False}
         return {"error": "unknown", "message": msg, "retryable": False}
+    except NoCredentialError as e:
+        return {"error": "no_credential", "message": str(e), "retryable": False}
     except CopilotAuthError as e:
         return {"error": "auth_failed", "message": str(e), "retryable": False}
     except CopilotUnavailableError as e:

--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -118,6 +118,16 @@ async def _initialize_copilot():
             _copilot.set_startup_error(CopilotUnavailableError(
                 f"Copilot initialization failed unexpectedly: {type(e).__name__}: {e}"
             ))
+        return
+
+    # start() can succeed without raising even when the SDK import failed
+    # (_init_sdk swallows ImportError, leaving is_connected=False).
+    if not _copilot.is_connected:
+        logger.error("Copilot SDK unavailable: client not connected after start()")
+        _copilot.set_startup_error(CopilotUnavailableError(
+            "Copilot SDK is not available. Ensure github-copilot-sdk is installed "
+            "and the Copilot CLI is running. Rebuild: docker compose build --no-cache"
+        ))
 
 
 @asynccontextmanager

--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -94,9 +94,9 @@ async def _initialize_copilot():
     try:
         resolved = resolver.resolve()
     except OSError as e:
-        logger.error("Credential resolver failed: %s", e)
+        logger.error("Credential resolver failed (%s)", type(e).__name__)
         _copilot.set_startup_error(CopilotUnavailableError(
-            f"Failed to resolve credentials: {type(e).__name__}: {e}"
+            f"Failed to resolve credentials: {type(e).__name__}"
         ))
         return
     if resolved is None:
@@ -114,9 +114,13 @@ async def _initialize_copilot():
         if isinstance(e, CopilotError):
             _copilot.set_startup_error(e)
         else:
-            logger.error("Unexpected error during Copilot initialization: %s", e, exc_info=True)
+            logger.error(
+                "Unexpected error during Copilot initialization (%s)",
+                type(e).__name__,
+                exc_info=True,
+            )
             _copilot.set_startup_error(CopilotUnavailableError(
-                f"Copilot initialization failed unexpectedly: {type(e).__name__}: {e}"
+                f"Copilot initialization failed unexpectedly: {type(e).__name__}"
             ))
         return
 

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -1,0 +1,142 @@
+/* AgentinaBox — monospace dark theme */
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+    font-family: "SF Mono", "Fira Code", "Cascadia Code", Menlo, Consolas, monospace;
+    background: #1a1a2e;
+    color: #e0e0e0;
+    line-height: 1.6;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+nav {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 1rem 2rem;
+    background: #16213e;
+    border-bottom: 1px solid #0f3460;
+}
+
+nav .brand {
+    font-weight: bold;
+    font-size: 1.1rem;
+    color: #e94560;
+    text-decoration: none;
+}
+
+nav a {
+    color: #a0a0b0;
+    text-decoration: none;
+}
+
+nav a:hover { color: #e0e0e0; }
+
+main {
+    flex: 1;
+    max-width: 720px;
+    width: 100%;
+    margin: 2rem auto;
+    padding: 0 1.5rem;
+}
+
+h1 { color: #e94560; margin-bottom: 1rem; font-size: 1.4rem; }
+h2 { color: #c0c0d0; margin-bottom: 0.75rem; font-size: 1.1rem; }
+
+.flash {
+    background: #0f3460;
+    border: 1px solid #e94560;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.5rem;
+    border-radius: 4px;
+}
+
+.error {
+    background: #3a0a0a;
+    border: 1px solid #e94560;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.5rem;
+    border-radius: 4px;
+    white-space: pre-wrap;
+}
+
+.card {
+    background: #16213e;
+    border: 1px solid #0f3460;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    border-radius: 4px;
+}
+
+label {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: #a0a0b0;
+}
+
+input[type="text"], input[type="password"], textarea {
+    width: 100%;
+    padding: 0.5rem;
+    background: #1a1a2e;
+    border: 1px solid #0f3460;
+    color: #e0e0e0;
+    font-family: inherit;
+    font-size: 0.9rem;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+}
+
+input:focus, textarea:focus {
+    outline: none;
+    border-color: #e94560;
+}
+
+button, .btn {
+    display: inline-block;
+    padding: 0.5rem 1.25rem;
+    background: #e94560;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 0.9rem;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+button:hover, .btn:hover { background: #c73652; }
+
+button:disabled {
+    background: #555;
+    cursor: not-allowed;
+}
+
+.meta {
+    color: #808090;
+    font-size: 0.85rem;
+}
+
+.token-display {
+    font-size: 1.1rem;
+    color: #e94560;
+    letter-spacing: 0.05em;
+}
+
+ol, ul { padding-left: 1.5rem; margin-bottom: 1rem; }
+li { margin-bottom: 0.3rem; }
+
+footer {
+    text-align: center;
+    padding: 1rem;
+    color: #606070;
+    font-size: 0.8rem;
+    border-top: 1px solid #0f3460;
+}
+
+.note {
+    color: #a0a0b0;
+    font-size: 0.85rem;
+    margin-top: 0.5rem;
+}

--- a/server/templates/_macros.html
+++ b/server/templates/_macros.html
@@ -1,0 +1,8 @@
+{% macro source_label(source) %}
+{%- if source == "docker_secret" %}Docker Secret
+{%- elif source == "env_var" %}Environment Variable
+{%- elif source == "stored" %}Stored (encrypted)
+{%- elif source == "none" %}Not configured
+{%- else %}{{ source }}
+{%- endif %}
+{% endmacro %}

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}AgentinaBox{% endblock %}</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <nav>
+        <a href="/" class="brand">AgentinaBox</a>
+        <a href="/settings">Settings</a>
+    </nav>
+    <main>
+        {% if message %}
+        <div class="flash">{{ message }}</div>
+        {% endif %}
+        {% block content %}{% endblock %}
+    </main>
+    <footer>
+        <p>AgentinaBox &mdash; AI Code Review Sidecar</p>
+    </footer>
+</body>
+</html>

--- a/server/templates/settings.html
+++ b/server/templates/settings.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import source_label %}
 {% block title %}Settings — Token Management{% endblock %}
 {% block content %}
 <h1>Settings</h1>
@@ -15,16 +16,7 @@
     <p class="token-display">No token configured</p>
     {% endif %}
     <p class="meta">
-        Source:
-        {% if source == "docker_secret" %}
-            Docker Secret
-        {% elif source == "env_var" %}
-            Environment Variable
-        {% elif source == "stored" %}
-            Encrypted Store
-        {% else %}
-            {{ source }}
-        {% endif %}
+        Source: {{ source_label(source) }}
     </p>
 </div>
 

--- a/server/templates/settings.html
+++ b/server/templates/settings.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% block title %}Settings — Token Management{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+
+{% if error %}
+<div class="error">{{ error }}</div>
+{% endif %}
+
+<div class="card">
+    <h2>Current Token</h2>
+    {% if masked_token %}
+    <p class="token-display">{{ masked_token }}</p>
+    {% else %}
+    <p class="token-display">No token configured</p>
+    {% endif %}
+    <p class="meta">
+        Source:
+        {% if source == "docker_secret" %}
+            Docker Secret
+        {% elif source == "env_var" %}
+            Environment Variable
+        {% elif source == "stored" %}
+            Encrypted Store
+        {% else %}
+            {{ source }}
+        {% endif %}
+    </p>
+</div>
+
+{% if can_rotate %}
+<div class="card">
+    <h2>Change Token</h2>
+    <form method="post" action="/settings/rotate">
+        <label for="token">New GitHub Personal Access Token</label>
+        <input type="password" id="token" name="token" placeholder="github_pat_..." required>
+        <p class="note">Your new token will be validated, then encrypted and stored, replacing the old one.</p>
+        <button type="submit">Save &amp; Test Connection</button>
+    </form>
+</div>
+{% else %}
+<div class="card">
+    <h2>Token Management</h2>
+    <p>This token is managed externally via
+        {% if source == "docker_secret" %}
+            a <strong>Docker secret</strong>.
+        {% elif source == "env_var" %}
+            the <strong>GITHUB_TOKEN</strong> environment variable.
+        {% else %}
+            an external source.
+        {% endif %}
+        To change it, update the external source and restart the container.
+    </p>
+</div>
+{% endif %}
+{% endblock %}

--- a/server/templates/settings.html
+++ b/server/templates/settings.html
@@ -30,6 +30,11 @@
         <button type="submit">Save &amp; Test Connection</button>
     </form>
 </div>
+{% elif source == "none" %}
+<div class="card">
+    <h2>Token Management</h2>
+    <p>No token is configured. <a href="/setup">Set up a token</a> to get started.</p>
+</div>
 {% else %}
 <div class="card">
     <h2>Token Management</h2>

--- a/server/templates/setup.html
+++ b/server/templates/setup.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block title %}Setup — Configure GitHub Token{% endblock %}
+{% block content %}
+<h1>Setup — Configure GitHub Token</h1>
+
+{% if error %}
+<div class="error">{{ error }}</div>
+{% endif %}
+
+<div class="card">
+    <h2>Create a Fine-Grained Personal Access Token</h2>
+    <ol>
+        <li>Go to <a href="https://github.com/settings/tokens?type=beta" target="_blank" rel="noopener">github.com/settings/tokens?type=beta</a></li>
+        <li>Click <strong>"Generate new token"</strong></li>
+        <li>Under <strong>Account permissions</strong>, enable <strong>copilot_requests</strong></li>
+        <li>Copy the token (starts with <code>github_pat_</code>)</li>
+    </ol>
+</div>
+
+<div class="card">
+    <form method="post" action="/setup">
+        <label for="token">GitHub Personal Access Token</label>
+        <input type="password" id="token" name="token" placeholder="github_pat_..." required>
+        <p class="note">Your token will be encrypted and stored securely inside the container.</p>
+        <button type="submit">Save &amp; Test Connection</button>
+    </form>
+</div>
+{% endblock %}

--- a/server/templates/status.html
+++ b/server/templates/status.html
@@ -4,7 +4,7 @@
 <h1>Credential Status</h1>
 
 <div class="card">
-    <h2>Stored Credential</h2>
+    <h2>Active Credential</h2>
     <p class="token-display">{{ masked_token }}</p>
     <p class="meta">
         Source:

--- a/server/templates/status.html
+++ b/server/templates/status.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Credential Status{% endblock %}
+{% block content %}
+<h1>Credential Status</h1>
+
+<div class="card">
+    <h2>Stored Credential</h2>
+    <p class="token-display">{{ masked_token }}</p>
+    <p class="meta">
+        Source:
+        {% if source == "docker_secret" %}
+            Docker Secret
+        {% elif source == "env_var" %}
+            Environment Variable
+        {% elif source == "stored" %}
+            Encrypted Store
+        {% else %}
+            {{ source }}
+        {% endif %}
+    </p>
+</div>
+
+<a href="/settings" class="btn">Settings</a>
+{% endblock %}

--- a/server/templates/status.html
+++ b/server/templates/status.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import source_label %}
 {% block title %}Credential Status{% endblock %}
 {% block content %}
 <h1>Credential Status</h1>
@@ -7,16 +8,7 @@
     <h2>Active Credential</h2>
     <p class="token-display">{{ masked_token }}</p>
     <p class="meta">
-        Source:
-        {% if source == "docker_secret" %}
-            Docker Secret
-        {% elif source == "env_var" %}
-            Environment Variable
-        {% elif source == "stored" %}
-            Encrypted Store
-        {% else %}
-            {{ source }}
-        {% endif %}
+        Source: {{ source_label(source) }}
     </p>
 </div>
 

--- a/server/token_validator.py
+++ b/server/token_validator.py
@@ -230,12 +230,16 @@ class TokenValidator:
                     _MSG_AUTH_LOW_CONFIDENCE, error_type="auth"
                 ) from None
         except Exception as e:
-            logger.error("Unexpected error during Copilot validation: %s", e, exc_info=True)
+            # Log only the exception type to avoid leaking potentially sensitive details
+            logger.error(
+                "Unexpected error during Copilot validation (type=%s)",
+                type(e).__name__,
+            )
             raise TokenValidationError(
                 "An unexpected error occurred while validating Copilot access. "
-                "Check container logs for details and try again.",
+                "Try again or contact your administrator.",
                 error_type="sdk",
-            ) from e
+            ) from None
         finally:
             try:
                 await client.stop()

--- a/server/token_validator.py
+++ b/server/token_validator.py
@@ -201,6 +201,10 @@ class TokenValidator:
         client = self._copilot_client_factory()
         try:
             await client.start(token)
+            # start() can complete without raising even when SDK import failed
+            # (_init_sdk swallows ImportError, leaving is_connected=False).
+            if not client.is_connected:
+                raise CopilotUnavailableError("SDK not connected after start")
         except (ImportError, CopilotUnavailableError):
             raise TokenValidationError(_MSG_SDK, error_type="sdk")
         except CopilotAuthError:
@@ -218,7 +222,7 @@ class TokenValidator:
             raise TokenValidationError(
                 "An unexpected error occurred while validating Copilot access. "
                 "Check container logs for details and try again.",
-                error_type="unknown",
+                error_type="sdk",
             )
         finally:
             await client.stop()
@@ -228,6 +232,9 @@ class TokenValidator:
 
         Three-step orchestration with short-circuiting on format and 401 auth errors.
         """
+        # Normalize whitespace once at the boundary (paste artifacts, trailing newlines)
+        token = token.strip()
+
         # Step 1: Format check (local, no network)
         self.validate_format(token)
 

--- a/server/token_validator.py
+++ b/server/token_validator.py
@@ -156,6 +156,15 @@ class TokenValidator:
         if not token or not token.strip():
             raise TokenValidationError(_MSG_FORMAT_EMPTY, error_type="format")
 
+        # Reject tokens with internal whitespace or control characters
+        # (could cause header injection in Authorization header)
+        if token != token.strip() or any(c.isspace() or ord(c) < 32 for c in token):
+            raise TokenValidationError(
+                "Token contains whitespace or control characters. "
+                "Remove any line breaks or spaces within the token.",
+                error_type="format",
+            )
+
         if token.startswith("ghp_"):
             raise TokenValidationError(_MSG_FORMAT_CLASSIC, error_type="format")
 

--- a/server/token_validator.py
+++ b/server/token_validator.py
@@ -24,6 +24,9 @@ from server.copilot_client import (
 )
 
 
+GITHUB_TOKEN_PREFIXES = ("github_pat_", "ghs_", "ghu_", "gho_", "ghp_")
+
+
 class TokenValidationError(Exception):
     """Raised when token validation fails."""
 
@@ -162,7 +165,7 @@ class TokenValidator:
         if token.startswith("ghs_") or token.startswith("ghu_"):
             raise TokenValidationError(_MSG_FORMAT_GITHUB_APP, error_type="format")
 
-        if not token.startswith("github_pat_"):
+        if not token.startswith(GITHUB_TOKEN_PREFIXES):
             raise TokenValidationError(_MSG_FORMAT_UNRECOGNIZED, error_type="format")
 
     async def _probe_github_auth(self, token: str) -> bool | None:
@@ -225,7 +228,10 @@ class TokenValidator:
                 error_type="sdk",
             ) from e
         finally:
-            await client.stop()
+            try:
+                await client.stop()
+            except Exception:
+                pass
 
     async def validate(self, token: str) -> None:
         """Full validation: format -> GitHub auth probe -> Copilot access.

--- a/server/token_validator.py
+++ b/server/token_validator.py
@@ -1,0 +1,238 @@
+"""Token validator — T012.
+
+Validates GitHub PAT format, GitHub authentication, and Copilot API access.
+Three-step sequence: format check -> GitHub auth probe -> Copilot access check.
+
+Per contracts/token-validator.md: verbose, diagnostic-style error messages
+with specific URLs and remediation steps for each error type.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import urllib.request
+import urllib.error
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+from server.copilot_client import (
+    CopilotAuthError,
+    CopilotReviewClient,
+    CopilotUnavailableError,
+)
+
+
+class TokenValidationError(Exception):
+    """Raised when token validation fails."""
+
+    def __init__(self, message: str, error_type: str) -> None:
+        self.message = message
+        self.error_type = error_type
+        super().__init__(message)
+
+
+# --- Error message templates (verbatim from contract) ---
+
+_MSG_FORMAT_EMPTY = """\
+No token provided. Please paste a GitHub fine-grained PAT.
+To create one:
+  \u2022 Go to github.com/settings/tokens?type=beta
+  \u2022 Click "Generate new token"
+  \u2022 Under Account permissions, enable 'copilot_requests'
+  \u2022 Copy the token (starts with github_pat_) and paste it here"""
+
+_MSG_FORMAT_CLASSIC = """\
+Classic PATs (ghp_) are not supported. AgentinaBox requires a fine-grained PAT
+with the copilot_requests permission.
+To create one:
+  \u2022 Go to github.com/settings/tokens?type=beta
+  \u2022 Click "Generate new token"
+  \u2022 Under Account permissions, enable 'copilot_requests'
+  \u2022 Copy the token (starts with github_pat_) and paste it here
+Classic PATs cannot scope to individual permissions \u2014 a fine-grained PAT is required."""
+
+_MSG_FORMAT_OAUTH = """\
+OAuth app tokens (gho_) are not supported. AgentinaBox requires a personal access
+token, not an OAuth token.
+To create one:
+  \u2022 Go to github.com/settings/tokens?type=beta
+  \u2022 Click "Generate new token" (fine-grained)
+  \u2022 Under Account permissions, enable 'copilot_requests'
+  \u2022 Copy the token (starts with github_pat_) and paste it here"""
+
+_MSG_FORMAT_GITHUB_APP = """\
+GitHub App tokens (ghs_/ghu_) are not supported. AgentinaBox requires a personal
+fine-grained PAT, not a GitHub App token.
+To create one:
+  \u2022 Go to github.com/settings/tokens?type=beta
+  \u2022 Click "Generate new token" (fine-grained)
+  \u2022 Under Account permissions, enable 'copilot_requests'
+  \u2022 Copy the token (starts with github_pat_) and paste it here"""
+
+_MSG_FORMAT_UNRECOGNIZED = """\
+Unrecognized token format. Expected a fine-grained PAT starting with 'github_pat_'.
+To create one:
+  \u2022 Go to github.com/settings/tokens?type=beta
+  \u2022 Click "Generate new token" (fine-grained)
+  \u2022 Under Account permissions, enable 'copilot_requests'
+  \u2022 Copy the token (starts with github_pat_) and paste it here"""
+
+_MSG_AUTH_HIGH_CONFIDENCE = """\
+Token authentication failed \u2014 the token appears to be expired or revoked.
+To fix this:
+  \u2022 Go to github.com/settings/tokens
+  \u2022 Check if the token is still active
+  \u2022 If expired, create a new fine-grained PAT with the 'copilot_requests' permission
+  \u2022 Paste the new token here to try again"""
+
+_MSG_AUTH_LOW_CONFIDENCE = """\
+Token validation failed \u2014 we couldn't determine the exact cause. This can happen if:
+  \u2022 The token is expired or revoked
+  \u2022 The token lacks the 'copilot_requests' permission
+  \u2022 Your account doesn't have a Copilot subscription
+  \u2022 GitHub or Copilot is temporarily unavailable
+Try creating a new fine-grained PAT at github.com/settings/tokens with the
+'copilot_requests' permission, and ensure you have an active Copilot subscription
+at github.com/settings/copilot."""
+
+_MSG_PERMISSION = """\
+Token authenticates to GitHub but cannot access Copilot. Common causes:
+  \u2022 Missing permission: Edit the token at github.com/settings/tokens and ensure
+    'copilot_requests' is enabled
+  \u2022 No Copilot subscription: Check your plan at github.com/settings/copilot
+  \u2022 Organization policy: Your org admin may need to enable Copilot for your account
+If you've verified all of the above and it still fails, try creating a fresh token."""
+
+_MSG_SDK = (
+    "Copilot SDK unavailable \u2014 cannot validate token. "
+    "This is a container configuration issue, not a problem with your token. "
+    "The Copilot CLI may not be installed or failed to start.\n"
+    "To fix this:\n"
+    "  \u2022 Rebuild the container: docker compose build --no-cache\n"
+    "  \u2022 Restart it: docker compose up -d\n"
+    "  \u2022 Check container logs for errors: docker compose logs\n"
+    "If the issue persists, verify the Dockerfile includes the Copilot CLI installation\n"
+    "step (npm install -g @github/copilot).\n"
+    "For Copilot CLI setup details, see: docs.github.com/en/copilot"
+)
+
+
+def _http_get_status(url: str, token: str) -> int:
+    """Make a GET request with Bearer auth and return the HTTP status code.
+
+    Uses urllib.request (stdlib). Module-level function for easy mocking in tests.
+    """
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("User-Agent", "AgentinaBox-TokenValidator")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+
+
+class TokenValidator:
+    """Validates tokens via: format -> GitHub auth probe -> Copilot access check."""
+
+    def __init__(
+        self,
+        copilot_client_factory: Callable[[], CopilotReviewClient],
+    ) -> None:
+        """Initialize with a factory callable that creates CopilotReviewClient instances."""
+        self._copilot_client_factory = copilot_client_factory
+
+    def validate_format(self, token: str) -> None:
+        """Check token prefix. Raises TokenValidationError(error_type="format") on failure.
+
+        Accepts: github_pat_ prefix.
+        Rejects with verbose, actionable messages including URLs.
+        """
+        if not token or not token.strip():
+            raise TokenValidationError(_MSG_FORMAT_EMPTY, error_type="format")
+
+        if token.startswith("ghp_"):
+            raise TokenValidationError(_MSG_FORMAT_CLASSIC, error_type="format")
+
+        if token.startswith("gho_"):
+            raise TokenValidationError(_MSG_FORMAT_OAUTH, error_type="format")
+
+        if token.startswith("ghs_") or token.startswith("ghu_"):
+            raise TokenValidationError(_MSG_FORMAT_GITHUB_APP, error_type="format")
+
+        if not token.startswith("github_pat_"):
+            raise TokenValidationError(_MSG_FORMAT_UNRECOGNIZED, error_type="format")
+
+    async def _probe_github_auth(self, token: str) -> bool | None:
+        """Diagnostic probe: check if token authenticates to GitHub.
+
+        Makes GET https://api.github.com/user with Bearer auth.
+        Returns True on 2xx, raises on 401, returns None otherwise.
+        """
+        try:
+            status = await asyncio.to_thread(
+                _http_get_status, "https://api.github.com/user", token
+            )
+        except (urllib.error.URLError, OSError, TimeoutError) as e:
+            logger.warning("GitHub auth probe failed (network error): %s", type(e).__name__)
+            return None
+
+        if 200 <= status < 300:
+            return True
+
+        if status == 401:
+            raise TokenValidationError(
+                _MSG_AUTH_HIGH_CONFIDENCE, error_type="auth"
+            )
+
+        # Any other status (403, 5xx, etc.) — inconclusive
+        return None
+
+    async def validate_copilot_access(
+        self, token: str, github_auth_confirmed: bool | None
+    ) -> None:
+        """Validate Copilot API access via list_models().
+
+        Uses github_auth_confirmed (from _probe_github_auth) for error classification.
+        Creates a temporary CopilotReviewClient, calls start(token), and stops it.
+        """
+        client = self._copilot_client_factory()
+        try:
+            await client.start(token)
+        except (ImportError, CopilotUnavailableError):
+            raise TokenValidationError(_MSG_SDK, error_type="sdk")
+        except CopilotAuthError:
+            if github_auth_confirmed is True:
+                raise TokenValidationError(
+                    _MSG_PERMISSION, error_type="permission"
+                )
+            else:
+                # Inconclusive probe — cannot distinguish auth from permission
+                raise TokenValidationError(
+                    _MSG_AUTH_LOW_CONFIDENCE, error_type="auth"
+                )
+        except Exception as e:
+            logger.error("Unexpected error during Copilot validation: %s", e, exc_info=True)
+            raise TokenValidationError(
+                "An unexpected error occurred while validating Copilot access. "
+                "Check container logs for details and try again.",
+                error_type="unknown",
+            )
+        finally:
+            await client.stop()
+
+    async def validate(self, token: str) -> None:
+        """Full validation: format -> GitHub auth probe -> Copilot access.
+
+        Three-step orchestration with short-circuiting on format and 401 auth errors.
+        """
+        # Step 1: Format check (local, no network)
+        self.validate_format(token)
+
+        # Step 2: GitHub auth probe (diagnostic, short-circuits only on 401)
+        github_confirmed = await self._probe_github_auth(token)
+
+        # Step 3: Copilot access check
+        await self.validate_copilot_access(token, github_auth_confirmed=github_confirmed)

--- a/server/token_validator.py
+++ b/server/token_validator.py
@@ -206,24 +206,24 @@ class TokenValidator:
             if not client.is_connected:
                 raise CopilotUnavailableError("SDK not connected after start")
         except (ImportError, CopilotUnavailableError):
-            raise TokenValidationError(_MSG_SDK, error_type="sdk")
+            raise TokenValidationError(_MSG_SDK, error_type="sdk") from None
         except CopilotAuthError:
             if github_auth_confirmed is True:
                 raise TokenValidationError(
                     _MSG_PERMISSION, error_type="permission"
-                )
+                ) from None
             else:
                 # Inconclusive probe — cannot distinguish auth from permission
                 raise TokenValidationError(
                     _MSG_AUTH_LOW_CONFIDENCE, error_type="auth"
-                )
+                ) from None
         except Exception as e:
             logger.error("Unexpected error during Copilot validation: %s", e, exc_info=True)
             raise TokenValidationError(
                 "An unexpected error occurred while validating Copilot access. "
                 "Check container logs for details and try again.",
                 error_type="sdk",
-            )
+            ) from e
         finally:
             await client.stop()
 

--- a/server/web_routes.py
+++ b/server/web_routes.py
@@ -19,6 +19,9 @@ from server.token_validator import TokenValidationError, TokenValidator
 
 logger = logging.getLogger(__name__)
 
+# Known GitHub token prefixes, longest first for greedy match
+_KNOWN_PREFIXES = ("github_pat_", "ghs_", "ghu_", "gho_", "ghp_")
+
 
 # --- Flash message mapping (query param ?msg= values) ---
 
@@ -36,8 +39,6 @@ def mask_token(token: str | None) -> str:
     """
     if not token:
         return ""
-    # Known GitHub token prefixes, longest first for greedy match
-    _KNOWN_PREFIXES = ("github_pat_", "ghs_", "ghu_", "gho_", "ghp_")
     prefix = ""
     for p in _KNOWN_PREFIXES:
         if token.startswith(p):
@@ -153,22 +154,22 @@ def create_router(
         """
         resolved = resolver.resolve()
         source = resolved.source if resolved else CredentialSource.NONE
+        can_rotate = source == CredentialSource.STORED
+        masked = mask_token(resolved.token) if resolved else None
+
+        ctx = {
+            "source": source.value,
+            "masked_token": masked,
+            "can_rotate": can_rotate,
+            "message": None,
+            "error": None,
+        }
 
         if source != CredentialSource.STORED:
             # Externally managed — reject rotation
             logger.warning("Rotation rejected: credential source is %s", source)
-            masked = mask_token(resolved.token) if resolved else None
-            return templates.TemplateResponse(
-                request,
-                "settings.html",
-                {
-                    "source": source.value,
-                    "masked_token": masked,
-                    "can_rotate": False,
-                    "message": None,
-                    "error": "Token is managed externally and cannot be rotated here.",
-                },
-            )
+            ctx["error"] = "Token is managed externally and cannot be rotated here."
+            return templates.TemplateResponse(request, "settings.html", ctx)
 
         token = token.strip()
         try:
@@ -176,35 +177,15 @@ def create_router(
         except TokenValidationError as e:
             # Validation failed — re-render with error, old token preserved
             logger.warning("Token validation failed: %s", e.error_type)
-            masked = mask_token(resolved.token) if resolved else None
-            return templates.TemplateResponse(
-                request,
-                "settings.html",
-                {
-                    "source": source.value,
-                    "masked_token": masked,
-                    "can_rotate": True,
-                    "message": None,
-                    "error": str(e),
-                },
-            )
+            ctx["error"] = str(e)
+            return templates.TemplateResponse(request, "settings.html", ctx)
 
         try:
             store.store(token)
         except OSError as e:
             logger.error("Failed to persist credential: %s", e)
-            masked = mask_token(resolved.token) if resolved else None
-            return templates.TemplateResponse(
-                request,
-                "settings.html",
-                {
-                    "source": source.value,
-                    "masked_token": masked,
-                    "can_rotate": True,
-                    "message": None,
-                    "error": "Failed to save the token to disk. Check that the /data/ volume is mounted and writable.",
-                },
-            )
+            ctx["error"] = "Failed to save the token to disk. Check that the /data/ volume is mounted and writable."
+            return templates.TemplateResponse(request, "settings.html", ctx)
 
         logger.info("Token rotated successfully")
         return RedirectResponse(url="/settings?msg=rotated", status_code=303)

--- a/server/web_routes.py
+++ b/server/web_routes.py
@@ -113,6 +113,7 @@ def create_router(
 
         try:
             store.store(token)
+            store.update_last_validated()
         except OSError as e:
             logger.error("Failed to persist credential: %s", e)
             return templates.TemplateResponse(
@@ -165,6 +166,11 @@ def create_router(
             "error": None,
         }
 
+        if source == CredentialSource.NONE:
+            logger.warning("Rotation rejected: no credential configured")
+            ctx["error"] = "No token is configured. Please set one up first via /setup."
+            return templates.TemplateResponse(request, "settings.html", ctx)
+
         if source != CredentialSource.STORED:
             # Externally managed — reject rotation
             logger.warning("Rotation rejected: credential source is %s", source)
@@ -182,6 +188,7 @@ def create_router(
 
         try:
             store.store(token)
+            store.update_last_validated()
         except OSError as e:
             logger.error("Failed to persist credential: %s", e)
             ctx["error"] = "Failed to save the token to disk. Check that the /data/ volume is mounted and writable."

--- a/server/web_routes.py
+++ b/server/web_routes.py
@@ -44,8 +44,9 @@ def mask_token(token: str | None) -> str:
             prefix = p
             break
     if not prefix:
-        # Unknown prefix — show first 4 chars
-        prefix = token[:4] if len(token) > 4 else token
+        if len(token) <= 4:
+            return "..."
+        prefix = token[:4]
     suffix_len = 4
     if len(token) <= len(prefix) + suffix_len:
         return prefix + "..."
@@ -98,6 +99,7 @@ def create_router(
     @router.post("/setup")
     async def setup_post(request: Request, token: str = Form(...)):
         """Validate and store token. PRG pattern: redirect on success."""
+        token = token.strip()
         try:
             await validator.validate(token)
         except TokenValidationError as e:
@@ -168,6 +170,7 @@ def create_router(
                 },
             )
 
+        token = token.strip()
         try:
             await validator.validate(token)
         except TokenValidationError as e:

--- a/server/web_routes.py
+++ b/server/web_routes.py
@@ -1,0 +1,209 @@
+"""Web routes for credential management UI — T015, T021.
+
+Routes: GET / (status/redirect), GET /setup (wizard), POST /setup (validate+store),
+GET /settings (view token/source), POST /settings/rotate (token rotation).
+Per contract: specs/002-credential-setup/contracts/web-routes.md
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Request, Form
+from fastapi.templating import Jinja2Templates
+from starlette.responses import RedirectResponse
+
+from server.credential_resolver import CredentialResolver, CredentialSource
+from server.credential_store import CredentialStore
+from server.token_validator import TokenValidationError, TokenValidator
+
+logger = logging.getLogger(__name__)
+
+
+# --- Flash message mapping (query param ?msg= values) ---
+
+_FLASH_MESSAGES = {
+    "saved": "Token saved successfully.",
+    "rotated": "Token rotated successfully.",
+}
+
+
+def mask_token(token: str | None) -> str:
+    """Mask token for display: actual prefix + '...' + last 4 chars.
+
+    Derives the prefix from the token itself (e.g. github_pat_, ghp_, gho_).
+    Returns empty string for None/empty input.
+    """
+    if not token:
+        return ""
+    # Known GitHub token prefixes, longest first for greedy match
+    _KNOWN_PREFIXES = ("github_pat_", "ghs_", "ghu_", "gho_", "ghp_")
+    prefix = ""
+    for p in _KNOWN_PREFIXES:
+        if token.startswith(p):
+            prefix = p
+            break
+    if not prefix:
+        # Unknown prefix — show first 4 chars
+        prefix = token[:4] if len(token) > 4 else token
+    suffix_len = 4
+    if len(token) <= len(prefix) + suffix_len:
+        return prefix + "..."
+    return prefix + "..." + token[-suffix_len:]
+
+
+def create_router(
+    templates: Jinja2Templates,
+    store: CredentialStore,
+    resolver: CredentialResolver,
+    validator: TokenValidator,
+) -> APIRouter:
+    """Create and return an APIRouter with credential management routes."""
+    router = APIRouter()
+
+    @router.get("/")
+    async def index(request: Request, msg: str | None = None):
+        """Credential status page. Redirects to /setup if no credential."""
+        resolved = resolver.resolve()
+        if resolved is None:
+            return RedirectResponse(url="/setup")
+
+        message = _FLASH_MESSAGES.get(msg) if msg else None
+        masked = mask_token(resolved.token)
+        source = resolved.source.value
+
+        return templates.TemplateResponse(
+            request,
+            "status.html",
+            {
+                "source": source,
+                "masked_token": masked,
+                "message": message,
+            },
+        )
+
+    @router.get("/setup")
+    async def setup_get(request: Request):
+        """Setup wizard. Redirects to / if credential already configured."""
+        resolved = resolver.resolve()
+        if resolved is not None:
+            return RedirectResponse(url="/")
+
+        return templates.TemplateResponse(
+            request,
+            "setup.html",
+            {"error": None},
+        )
+
+    @router.post("/setup")
+    async def setup_post(request: Request, token: str = Form(...)):
+        """Validate and store token. PRG pattern: redirect on success."""
+        try:
+            await validator.validate(token)
+        except TokenValidationError as e:
+            logger.warning("Token validation failed: %s", e.error_type)
+            return templates.TemplateResponse(
+                request,
+                "setup.html",
+                {"error": str(e)},
+            )
+
+        try:
+            store.store(token)
+        except OSError as e:
+            logger.error("Failed to persist credential: %s", e)
+            return templates.TemplateResponse(
+                request,
+                "setup.html",
+                {"error": "Failed to save the token to disk. Check that the /data/ volume is mounted and writable."},
+            )
+
+        logger.info("Token stored successfully (source: setup wizard)")
+        return RedirectResponse(url="/?msg=saved", status_code=303)
+
+    @router.get("/settings")
+    async def settings_get(request: Request, msg: str | None = None):
+        """Settings page — show masked token, source, rotation form (FR-006)."""
+        resolved = resolver.resolve()
+        source = resolved.source if resolved else CredentialSource.NONE
+        can_rotate = source == CredentialSource.STORED
+
+        masked = mask_token(resolved.token) if resolved else None
+        message = _FLASH_MESSAGES.get(msg) if msg else None
+
+        return templates.TemplateResponse(
+            request,
+            "settings.html",
+            {
+                "source": source.value,
+                "masked_token": masked,
+                "can_rotate": can_rotate,
+                "message": message,
+                "error": None,
+            },
+        )
+
+    @router.post("/settings/rotate")
+    async def settings_rotate(request: Request, token: str = Form(...)):
+        """Rotate token — validate, replace, redirect (PRG pattern, FR-006).
+
+        Only allowed when source is 'stored'. Rejects if externally managed.
+        """
+        resolved = resolver.resolve()
+        source = resolved.source if resolved else CredentialSource.NONE
+
+        if source != CredentialSource.STORED:
+            # Externally managed — reject rotation
+            logger.warning("Rotation rejected: credential source is %s", source)
+            masked = mask_token(resolved.token) if resolved else None
+            return templates.TemplateResponse(
+                request,
+                "settings.html",
+                {
+                    "source": source.value,
+                    "masked_token": masked,
+                    "can_rotate": False,
+                    "message": None,
+                    "error": "Token is managed externally and cannot be rotated here.",
+                },
+            )
+
+        try:
+            await validator.validate(token)
+        except TokenValidationError as e:
+            # Validation failed — re-render with error, old token preserved
+            logger.warning("Token validation failed: %s", e.error_type)
+            masked = mask_token(resolved.token) if resolved else None
+            return templates.TemplateResponse(
+                request,
+                "settings.html",
+                {
+                    "source": source.value,
+                    "masked_token": masked,
+                    "can_rotate": True,
+                    "message": None,
+                    "error": str(e),
+                },
+            )
+
+        try:
+            store.store(token)
+        except OSError as e:
+            logger.error("Failed to persist credential: %s", e)
+            masked = mask_token(resolved.token) if resolved else None
+            return templates.TemplateResponse(
+                request,
+                "settings.html",
+                {
+                    "source": source.value,
+                    "masked_token": masked,
+                    "can_rotate": True,
+                    "message": None,
+                    "error": "Failed to save the token to disk. Check that the /data/ volume is mounted and writable.",
+                },
+            )
+
+        logger.info("Token rotated successfully")
+        return RedirectResponse(url="/settings?msg=rotated", status_code=303)
+
+    return router

--- a/specs/002-credential-setup/checklists/requirements.md
+++ b/specs/002-credential-setup/checklists/requirements.md
@@ -1,0 +1,45 @@
+# Requirements Quality Checklist — 002-credential-setup
+
+## Spec Structure
+
+- [x] All mandatory sections present (User Scenarios, Requirements, Success Criteria)
+- [x] User stories prioritized (P1, P2, P3)
+- [x] Each user story independently testable
+- [x] Each user story has acceptance scenarios in Given/When/Then format
+- [x] Edge cases section populated with concrete behaviors (not open questions)
+
+## Requirements Quality
+
+- [x] All FRs use MUST/SHOULD/MAY language correctly
+- [x] All FRs are testable with concrete pass/fail criteria
+- [x] No implementation details leak into FRs (technology-agnostic where possible)
+  - Note: FR-001 names Fernet and FR-002 names Docker secret path — these are constrained by the constitution's tech stack, not premature implementation decisions
+- [x] FR-003: Enumerates all rejected token prefixes (`ghp_`, `gho_`, `ghs_`, `ghu_`)
+- [x] FR-005: Specifies the exact validation method (`list_models()`) and 4 distinct failure modes (format error, auth error, permission error, SDK error). Permission error broadened to "cannot access Copilot" per coordinator decision. All messages must be verbose with URLs and remediation steps.
+- [x] FR-006: Specifies masking format (`github_pat_...XXXX`)
+- [x] FR-007: Covers logs, API responses, web UI, and error messages
+- [x] FR-008: Specifies the exact port binding format
+- [x] FR-009: Credential status page at `/` — shows source + masked token only, no connection status claims
+- [x] FR-010: MCP freshness boundary — resolved at process startup, rotation effective on next connection
+
+## Success Criteria
+
+- [x] All SCs are measurable
+- [x] SC-001: Time-based (under 2 minutes)
+- [x] SC-002: Behavioral (no restart, next MCP connection uses new token, active sessions keep their token)
+- [x] SC-003: Verifiable (grep-based check)
+- [x] SC-004: Combinatorial (all 4 source combinations)
+- [x] SC-005: Qualitative but testable (specific error messages for each rejection type)
+
+## Constitution Compliance
+
+- [x] No hardcoded repo knowledge (project-agnostic)
+- [x] No host volume mounts (Docker named volume only)
+- [x] Security boundary maintained (only GitHub PAT enters container)
+- [x] TDD compatible (all requirements have testable pass/fail criteria)
+- [x] YAGNI: no external KMS, no RBAC, no multi-user
+
+## Remaining Risks
+
+- Copilot SDK (`github-copilot-sdk>=0.1.0`) is Technical Preview — `list_models()` API may change. Mitigation: document assumption, design fallback path in design phase.
+- Docker Compose secrets without Swarm are file mounts with no Docker-level encryption. Mitigation: Fernet layer provides at-rest encryption; this is documented in the spec rationale.

--- a/specs/002-credential-setup/contracts/credential-resolver.md
+++ b/specs/002-credential-setup/contracts/credential-resolver.md
@@ -1,0 +1,67 @@
+# Credential Resolver Contract: Credential Setup (002)
+
+## Module: `server/credential_resolver.py`
+
+Resolves the active credential from the highest-priority available source.
+
+## Interface
+
+```python
+from enum import Enum
+
+class CredentialSource(str, Enum):
+    DOCKER_SECRET = "docker_secret"
+    ENV_VAR = "env_var"
+    STORED = "stored"
+    NONE = "none"
+
+
+@dataclass
+class ResolvedCredential:
+    """In-memory only. Never persisted."""
+    token: str
+    source: CredentialSource
+
+
+class CredentialResolver:
+    """Resolves credentials from multiple sources in priority order."""
+
+    def __init__(
+        self,
+        store: CredentialStore,
+        docker_secret_path: str = "/run/secrets/github_token",
+    ) -> None:
+        """Initialize with credential store and Docker secret path."""
+
+    def resolve(self) -> ResolvedCredential | None:
+        """Resolve credential from highest-priority source.
+
+        Priority order (FR-002):
+          1. Docker secret (file at /run/secrets/github_token)
+          2. Environment variable (GITHUB_TOKEN)
+          3. Stored credential (decrypted from /data/)
+
+        Returns None if no source provides a credential.
+        Strips whitespace from all sources (Docker secrets often have trailing newlines).
+        """
+
+    def get_source(self) -> CredentialSource:
+        """Return the source type without exposing the token.
+
+        Useful for the credential status page (FR-009).
+        """
+```
+
+## Behavior
+
+- **Priority order**: Docker secret > env var > stored. First non-empty source wins.
+- **Whitespace stripping**: All sources are `.strip()`'d before use (spec edge case: Docker secret trailing newline).
+- **No validation**: Returns whatever token the source provides. Validation is `TokenValidator`'s job.
+- **No caching**: Each `resolve()` call reads fresh from sources. This supports FR-010 (MCP freshness).
+- **Logging**: Logs the resolved source type (e.g., "Credential resolved from docker_secret"). Never logs the token value (FR-007).
+
+## Dependencies
+
+- `CredentialStore` — for reading stored credentials
+- `os.environ` — for `GITHUB_TOKEN`
+- File I/O — for Docker secret file

--- a/specs/002-credential-setup/contracts/credential-store.md
+++ b/specs/002-credential-setup/contracts/credential-store.md
@@ -1,0 +1,82 @@
+# Credential Store Contract: Credential Setup (002)
+
+## Module: `server/credential_store.py`
+
+Manages Fernet-encrypted credential persistence in the Docker named volume (`/data/`).
+
+## Interface
+
+```python
+class CredentialStore:
+    """Manages encrypted credential storage in /data/."""
+
+    def __init__(self, data_dir: str = "/data") -> None:
+        """Initialize with data directory path."""
+
+    def store(self, token: str) -> None:
+        """Encrypt and persist a token. Creates Fernet key on first use.
+
+        Writes:
+          - /data/.fernet_key (if not exists, chmod 600)
+          - /data/credentials.enc (Fernet-encrypted token bytes)
+          - /data/credential_meta.json (created_at, last_validated_at as ISO 8601)
+
+        Uses os.replace() for atomic writes to minimize corruption risk.
+        """
+
+    def load(self) -> str | None:
+        """Load and decrypt the stored token. Returns None if unavailable.
+
+        Returns None when:
+          - No credentials.enc file exists
+          - No .fernet_key file exists (key loss — per spec edge case)
+          - Decryption fails (corrupted file or key mismatch)
+
+        Logs a warning (without token data) on key loss or decryption failure.
+        """
+
+    def delete(self) -> None:
+        """Remove stored credential files (credentials.enc + credential_meta.json).
+
+        Does NOT remove .fernet_key — it may be reused for future storage.
+        """
+
+    def get_metadata(self) -> CredentialMetadata | None:
+        """Read credential_meta.json. Returns None if file doesn't exist."""
+
+    def update_last_validated(self) -> None:
+        """Update last_validated_at in credential_meta.json to now."""
+
+    def has_stored_credential(self) -> bool:
+        """Check if credentials.enc exists (without decrypting)."""
+```
+
+## Data Types
+
+```python
+from dataclasses import dataclass
+from datetime import datetime
+
+@dataclass
+class CredentialMetadata:
+    created_at: datetime
+    last_validated_at: datetime
+```
+
+## Behavior
+
+- **Fernet key lifecycle**: Auto-generated via `Fernet.generate_key()` on first `store()` call. Persisted at `/data/.fernet_key` with `chmod 600`. Never regenerated — loss invalidates all stored credentials.
+- **Atomic writes**: All file writes use a temp file + `os.replace()` pattern.
+- **No validation**: This module encrypts/decrypts only. Token validation is `TokenValidator`'s responsibility.
+- **Thread safety**: Not required. Web server is single-process (uvicorn). MCP is per-invocation.
+
+## Error Handling
+
+- Key loss (`.fernet_key` missing but `credentials.enc` exists): log warning, return `None` from `load()`.
+- Decryption failure (`InvalidToken` from Fernet): log warning, return `None` from `load()`.
+- File I/O errors: propagate as-is (callers handle).
+
+## Dependencies
+
+- `cryptography.fernet.Fernet` — encryption/decryption
+- Standard library: `os`, `json`, `datetime`

--- a/specs/002-credential-setup/contracts/token-validator.md
+++ b/specs/002-credential-setup/contracts/token-validator.md
@@ -1,0 +1,217 @@
+# Token Validator Contract: Credential Setup (002)
+
+## Module: `server/token_validator.py`
+
+Validates GitHub PAT format, GitHub authentication, and Copilot API access.
+
+## Interface
+
+```python
+class TokenValidationError(Exception):
+    """Raised when token validation fails."""
+    message: str
+    error_type: str  # "format", "auth", "permission", "sdk"
+
+
+class TokenValidator:
+    """Validates tokens via: format → GitHub auth probe → Copilot access check."""
+
+    def __init__(self, copilot_client: CopilotReviewClient) -> None:
+        """Initialize with Copilot client for SDK validation."""
+
+    def validate_format(self, token: str) -> None:
+        """Check token prefix. Raises TokenValidationError(error_type="format") on failure.
+
+        Accepts: github_pat_ prefix
+        Rejects with verbose, actionable messages including URLs:
+          - Empty/whitespace-only: "No token provided. ..."
+          - ghp_: "Classic PATs (ghp_) are not supported. ..."
+          - gho_: "OAuth app tokens (gho_) are not supported. ..."
+          - ghs_: "GitHub App server-to-server tokens (ghs_) are not supported. ..."
+          - ghu_: "GitHub App user-to-server tokens (ghu_) are not supported. ..."
+          - Other: "Unrecognized token format. ..."
+        See Error Messages section below for full message templates.
+        """
+
+    async def _probe_github_auth(self, token: str) -> bool | None:
+        """Diagnostic probe: check if token authenticates to GitHub.
+
+        Makes GET https://api.github.com/user with Bearer auth.
+        This is a diagnostic probe for error classification, NOT a validation gate.
+
+        Returns:
+          - True: HTTP 2xx — token authenticates to GitHub (auth confirmed)
+          - None: non-401, non-2xx (403 rate limit, 5xx, network error) — inconclusive
+
+        Raises:
+          - TokenValidationError(error_type="auth"): HTTP 401 — token is definitely
+            expired, revoked, or invalid. Message: "Token authentication failed —
+            the token may be expired or revoked. Please create a new fine-grained PAT."
+
+        Only 401 is treated as a definitive auth failure. Other non-2xx responses
+        are NOT mapped to auth — they are returned as None (inconclusive) so the
+        Copilot check can still run and provide its own classification.
+
+        Uses urllib.request (stdlib) via asyncio.to_thread(). No new dependencies.
+        """
+
+    async def validate_copilot_access(
+        self, token: str, github_auth_confirmed: bool | None
+    ) -> None:
+        """Validate Copilot API access via list_models().
+
+        Uses github_auth_confirmed (from _probe_github_auth) for error classification:
+
+        If CopilotAuthError is raised by the SDK:
+          - github_auth_confirmed is True → error_type="permission"
+            Token works for GitHub but not Copilot. Message covers the likely causes:
+            missing copilot_requests permission, no Copilot subscription, or policy.
+          - github_auth_confirmed is None (probe was inconclusive) → error_type="auth"
+            Cannot distinguish auth from permission. Combined message covers both.
+
+        If ImportError or CopilotUnavailableError:
+          - error_type="sdk" regardless of github_auth_confirmed
+
+        Per R-4 confidence model: we only claim "permission" when we have high
+        confidence (GitHub auth was confirmed). Otherwise we fall back honestly.
+        """
+
+    async def validate(self, token: str) -> None:
+        """Full validation: format → GitHub auth probe → Copilot access.
+
+        Orchestration:
+        1. validate_format(token) — local prefix check, no network
+        2. github_confirmed = _probe_github_auth(token)
+           - Raises "auth" on 401 (short-circuit, definitive)
+           - Returns True on 2xx (auth confirmed)
+           - Returns None on other failures (inconclusive, proceed)
+        3. validate_copilot_access(token, github_auth_confirmed=github_confirmed)
+           - True → "permission" on CopilotAuthError
+           - None → "auth" (combined msg) on CopilotAuthError
+           - "sdk" on ImportError/CopilotUnavailableError regardless
+
+        The GitHub auth probe is diagnostic, not a gate. If it's inconclusive
+        (returned None), the Copilot check still runs. The probe only gates
+        on HTTP 401, which is a definitive "token is invalid" signal.
+        """
+```
+
+## Error Messages
+
+Per R-4 confidence model and coordinator decision (Option A: verbose, diagnostic-style messages).
+All messages MUST be chatty — list possible causes and include specific URLs and remediation steps.
+
+### format — Empty/whitespace
+```
+No token provided. Please paste a GitHub fine-grained PAT.
+To create one:
+  • Go to github.com/settings/tokens?type=beta
+  • Click "Generate new token"
+  • Under Account permissions, enable 'copilot_requests'
+  • Copy the token (starts with github_pat_) and paste it here
+```
+
+### format — Classic PAT (ghp_)
+```
+Classic PATs (ghp_) are not supported. AgentinaBox requires a fine-grained PAT
+with the copilot_requests permission.
+To create one:
+  • Go to github.com/settings/tokens?type=beta
+  • Click "Generate new token"
+  • Under Account permissions, enable 'copilot_requests'
+  • Copy the token (starts with github_pat_) and paste it here
+Classic PATs cannot scope to individual permissions — a fine-grained PAT is required.
+```
+
+### format — OAuth app token (gho_)
+```
+OAuth app tokens (gho_) are not supported. AgentinaBox requires a personal access
+token, not an OAuth token.
+To create one:
+  • Go to github.com/settings/tokens?type=beta
+  • Click "Generate new token" (fine-grained)
+  • Under Account permissions, enable 'copilot_requests'
+  • Copy the token (starts with github_pat_) and paste it here
+```
+
+### format — GitHub App tokens (ghs_, ghu_)
+```
+GitHub App tokens (ghs_/ghu_) are not supported. AgentinaBox requires a personal
+fine-grained PAT, not a GitHub App token.
+To create one:
+  • Go to github.com/settings/tokens?type=beta
+  • Click "Generate new token" (fine-grained)
+  • Under Account permissions, enable 'copilot_requests'
+  • Copy the token (starts with github_pat_) and paste it here
+```
+
+### format — Unrecognized
+```
+Unrecognized token format. Expected a fine-grained PAT starting with 'github_pat_'.
+To create one:
+  • Go to github.com/settings/tokens?type=beta
+  • Click "Generate new token" (fine-grained)
+  • Under Account permissions, enable 'copilot_requests'
+  • Copy the token (starts with github_pat_) and paste it here
+```
+
+### auth — High confidence (HTTP 401 from GET /user)
+```
+Token authentication failed — the token appears to be expired or revoked.
+To fix this:
+  • Go to github.com/settings/tokens
+  • Check if the token is still active
+  • If expired, create a new fine-grained PAT with the 'copilot_requests' permission
+  • Paste the new token here to try again
+```
+
+### auth — Low confidence (inconclusive probe + Copilot failure)
+```
+Token validation failed — we couldn't determine the exact cause. This can happen if:
+  • The token is expired or revoked
+  • The token lacks the 'copilot_requests' permission
+  • Your account doesn't have a Copilot subscription
+  • GitHub or Copilot is temporarily unavailable
+Try creating a new fine-grained PAT at github.com/settings/tokens with the
+'copilot_requests' permission, and ensure you have an active Copilot subscription
+at github.com/settings/copilot.
+```
+
+### permission — High confidence (confirmed GitHub auth + Copilot failure)
+```
+Token authenticates to GitHub but cannot access Copilot. Common causes:
+  • Missing permission: Edit the token at github.com/settings/tokens and ensure
+    'copilot_requests' is enabled
+  • No Copilot subscription: Check your plan at github.com/settings/copilot
+  • Organization policy: Your org admin may need to enable Copilot for your account
+If you've verified all of the above and it still fails, try creating a fresh token.
+```
+
+### sdk
+```
+Copilot SDK unavailable — cannot validate token. This is a container configuration
+issue, not a problem with your token. The Copilot CLI may not be installed or
+failed to start.
+To fix this:
+  • Rebuild the container: docker compose build --no-cache
+  • Restart it: docker compose up -d
+  • Check container logs for errors: docker compose logs
+If the issue persists, verify the Dockerfile includes the Copilot CLI installation
+step (npm install -g @github/copilot).
+For Copilot CLI setup details, see: docs.github.com/en/copilot
+```
+
+## Behavior
+
+- **Three-step sequence**: format → GitHub auth probe → Copilot access. Format short-circuits. Auth probe short-circuits only on 401.
+- **Diagnostic probe, not gate**: `_probe_github_auth()` is purely for error classification. If inconclusive, the Copilot check still runs. The validator never blocks on a non-401 GET /user failure.
+- **Confidence-based classification**: "permission" is only claimed when we have strong evidence (GitHub auth confirmed + Copilot failed). "auth" fallback is used when evidence is insufficient.
+- **Temporary client**: `validate_copilot_access()` creates a temporary `CopilotReviewClient`, calls `start(token)`, and stops it. The token is not stored by the validator.
+- **No side effects**: Validation does not store, persist, or cache anything. The caller (`web_routes`) decides whether to store after successful validation.
+
+## Dependencies
+
+- `CopilotReviewClient` — for `start()` + `list_models()` validation
+- `CopilotAuthError`, `CopilotUnavailableError` — for error classification
+- `urllib.request` (stdlib) — for GitHub API auth probe
+- `asyncio.to_thread` (stdlib) — to run synchronous urllib in async context

--- a/specs/002-credential-setup/contracts/web-routes.md
+++ b/specs/002-credential-setup/contracts/web-routes.md
@@ -1,0 +1,126 @@
+# Web Routes Contract: Credential Setup (002)
+
+## Module: `server/web_routes.py`
+
+FastAPI routes for credential management web UI (setup wizard, settings, status page).
+
+## Routes
+
+### GET `/` — Credential Status Page (FR-009)
+
+**Behavior**:
+- If no credential is configured (resolver returns `None`): redirect to `/setup`
+- Otherwise: render status page showing source + masked token
+
+**Template**: `templates/status.html`
+
+**Context**:
+```python
+{
+    "source": "docker_secret" | "env_var" | "stored",
+    "masked_token": "github_pat_...XXXX",  # prefix + last 4 chars
+    "message": str | None,  # flash message from query param ?msg=
+}
+```
+
+**Note**: Page MUST NOT claim connection status or validity (FR-009).
+
+---
+
+### GET `/setup` — Setup Wizard (FR-004)
+
+**Behavior**:
+- If a credential is already configured: redirect to `/`
+- Otherwise: render setup wizard with PAT creation instructions
+
+**Template**: `templates/setup.html`
+
+**Context**:
+```python
+{
+    "error": str | None,  # validation error message from failed POST
+}
+```
+
+---
+
+### POST `/setup` — Submit Token (FR-004, FR-005)
+
+**Behavior**:
+1. Read `token` from form body
+2. Call `TokenValidator.validate(token)` — format + Copilot access
+3. On success: `CredentialStore.store(token)`, redirect to `/?msg=saved`
+4. On failure: re-render `/setup` with error message from `TokenValidationError`
+
+**Form field**: `token` (text input)
+
+**PRG pattern**: POST validates + stores, then redirects (GET) to status page.
+
+---
+
+### GET `/settings` — Settings Page (FR-006)
+
+**Behavior**:
+- Show masked current token and credential source
+- If source is `stored`: show change form
+- If source is `docker_secret` or `env_var`: disable form, show explanation
+
+**Template**: `templates/settings.html`
+
+**Context**:
+```python
+{
+    "source": CredentialSource,
+    "masked_token": str | None,
+    "can_rotate": bool,  # True only when source is "stored"
+    "message": str | None,
+    "error": str | None,
+}
+```
+
+---
+
+### POST `/settings/rotate` — Rotate Token (FR-006)
+
+**Behavior**:
+1. Check source is `stored` — reject if externally managed
+2. Read `token` from form body
+3. Call `TokenValidator.validate(token)`
+4. On success: `CredentialStore.store(token)` (replaces old), redirect to `/settings?msg=rotated`
+5. On failure: re-render `/settings` with error message, old token preserved
+
+---
+
+## Shared Helpers
+
+```python
+def mask_token(token: str) -> str:
+    """Mask token for display: 'github_pat_...XXXX' (prefix + last 4 chars).
+
+    Returns empty string for None/empty input.
+    """
+```
+
+## Templates
+
+All templates extend `templates/base.html` (monospace dark theme, single CSS).
+
+| Template | Route | Purpose |
+|----------|-------|---------|
+| `base.html` | — | Layout: nav, flash messages, footer |
+| `status.html` | `GET /` | Source + masked token display |
+| `setup.html` | `GET /setup` | PAT instructions + token input form |
+| `settings.html` | `GET /settings` | Masked token + rotation form |
+
+## Flash Messages
+
+Via query parameter `?msg=` (not session-based, per R-5 YAGNI decision):
+- `saved` → "Token saved successfully."
+- `rotated` → "Token rotated successfully."
+
+## Dependencies
+
+- `CredentialResolver` — resolve current credential source
+- `CredentialStore` — store/load credentials
+- `TokenValidator` — validate tokens before storing
+- `FastAPI`, `Jinja2Templates`, `Request`, `Form`

--- a/specs/002-credential-setup/contracts/web-routes.md
+++ b/specs/002-credential-setup/contracts/web-routes.md
@@ -94,7 +94,7 @@ FastAPI routes for credential management web UI (setup wizard, settings, status 
 ## Shared Helpers
 
 ```python
-def mask_token(token: str) -> str:
+def mask_token(token: str | None) -> str:
     """Mask token for display: 'github_pat_...XXXX' (prefix + last 4 chars).
 
     Returns empty string for None/empty input.

--- a/specs/002-credential-setup/data-model.md
+++ b/specs/002-credential-setup/data-model.md
@@ -1,0 +1,87 @@
+# Data Model — 002-credential-setup
+
+## Entities
+
+### StoredCredential
+
+Persisted as encrypted file at `/data/credentials.enc`. Not a database record.
+
+| Field | Type | Storage | Notes |
+|-------|------|---------|-------|
+| token | str | Fernet-encrypted in `/data/credentials.enc` | The raw PAT value. Never logged or displayed in plaintext. |
+| created_at | datetime (ISO 8601) | Plaintext in `/data/credential_meta.json` | When the token was first stored. |
+| last_validated_at | datetime (ISO 8601) | Plaintext in `/data/credential_meta.json` | When the token last passed `list_models()` validation. Updated on store and rotate. |
+
+**File layout under `/data/`:**
+```
+/data/
+  .fernet_key           # 44-byte Fernet key (chmod 600)
+  credentials.enc       # Fernet-encrypted token bytes
+  credential_meta.json  # {"created_at": "...", "last_validated_at": "..."}
+```
+
+**Rationale for separate metadata file**: The Fernet ciphertext is opaque binary. Metadata (timestamps) doesn't need encryption and is useful for the status page display without decrypting the token.
+
+### CredentialSource (Enum)
+
+```python
+class CredentialSource(str, Enum):
+    DOCKER_SECRET = "docker_secret"
+    ENV_VAR = "env_var"
+    STORED = "stored"
+    NONE = "none"
+```
+
+### ResolvedCredential (Value Object)
+
+In-memory only. Never persisted.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| token | str | The plaintext PAT value. |
+| source | CredentialSource | Which source provided this token. |
+
+### TokenValidationError (Exception)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| message | str | User-facing error message. |
+| error_type | str | One of: `"format"`, `"auth"`, `"permission"`, `"sdk"`. |
+
+**Error type mapping** (matches FR-005's 4 failure modes, see R-4 confidence model in research.md):
+- `"format"` — token has rejected prefix or is empty (local check, no network)
+- `"auth"` — token definitely fails GitHub authentication (`GET /user` returns 401 → expired/revoked), OR inconclusive fallback when GitHub auth probe returned non-401 non-2xx and Copilot also failed (combined message covers both auth and permission possibilities)
+- `"permission"` — token confirmed to authenticate to GitHub (`GET /user` returned 2xx) but `list_models()` fails → cannot access Copilot. Verbose message lists common causes (missing `copilot_requests` permission, no Copilot subscription, org policy) with specific remediation steps and URLs
+- `"sdk"` — Copilot SDK not installed or CLI won't start (ImportError / CopilotUnavailableError)
+
+### NoCredentialError (CopilotError)
+
+Raised internally when no credential source is available. Extends `CopilotError` (defined in `server/copilot_client.py`) so it fits the existing `_startup_error: CopilotError | None` type without changing the runtime error hierarchy. `retryable = False`. Does not escape the MCP tool boundary — caught by a dedicated handler in `start_review` and mapped to an error response payload.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| message | str | User-facing error message directing user to configure a credential. |
+
+**Usage**: Set as `_startup_error` on `CopilotReviewClient` when `CredentialResolver.resolve()` returns `None` during MCP lifespan initialization. The existing `_startup_error` check in `create_review_session()` re-raises it via `CopilotError` base class. At the MCP tool boundary, only `start_review` reaches `create_review_session()` — a dedicated `except NoCredentialError` handler there maps it to `{"error": "no_credential", "message": str(e), "retryable": False}` (distinct from `"unavailable"` and `"auth_failed"`). Other tools never encounter this error: `discuss` calls `send_followup()` → `send_review()` on existing sessions (never checks `_startup_error`); `get_review_summary` and `list_sessions` access only the session store.
+
+## Relationships
+
+```
+CredentialResolver --resolves--> ResolvedCredential
+  reads from: Docker secret file, env var, CredentialStore
+
+CredentialStore --manages--> StoredCredential
+  encrypts/decrypts via: Fernet key
+
+TokenValidator --validates--> token (str)
+  step 1: validate_format() — local prefix check
+  step 2: _probe_github_auth() — GET /user via urllib.request (diagnostic, not gate)
+           returns True (auth confirmed), None (inconclusive), or raises auth on 401
+  step 3: validate_copilot_access(token, github_auth_confirmed) — list_models()
+           uses probe result for error classification
+  raises: TokenValidationError (format | auth | permission | sdk)
+
+Web Routes --uses--> CredentialResolver, CredentialStore, TokenValidator
+MCP Server --uses--> CredentialResolver (read-only at startup)
+  on resolve() == None → sets NoCredentialError as _startup_error
+```

--- a/specs/002-credential-setup/plan.md
+++ b/specs/002-credential-setup/plan.md
@@ -1,0 +1,141 @@
+# Implementation Plan: Credential Setup & Management
+
+**Branch**: `002-credential-setup` | **Date**: 2026-03-22 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/002-credential-setup/spec.md`
+
+## Summary
+
+Implement secure credential management for AgentinaBox: Fernet-encrypted PAT storage in a Docker named volume, three-source credential resolution (Docker secret > env var > stored), format + Copilot SDK validation, and a server-rendered web UI for setup and rotation.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+
+**Primary Dependencies**: FastAPI 0.128+, uvicorn, cryptography (Fernet), Jinja2, pydantic 2.12+
+**Storage**: Fernet-encrypted files in Docker named volume (`/data/`)
+**Testing**: pytest, pytest-asyncio
+**Target Platform**: Linux (Docker container, `python:3.11-slim-bookworm` + Node.js 22)
+**Project Type**: Web service (FastAPI) + MCP server (stdio)
+**Constraints**: Localhost-only web UI, no shared memory between web/MCP processes
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Project-Agnostic | PASS | Credential management is container-level, not project-specific |
+| II. No Volume Mounts | PASS | `/data/` is a Docker named volume, not a host bind mount |
+| III. Security Boundary | PASS | Fernet encryption at rest, localhost binding, fine-grained PAT only, never log tokens |
+| IV. Test-First | PASS | TDD required for all modules |
+| V. Model-Agnostic | PASS | Validation uses `list_models()` — no hardcoded model IDs |
+| VI. Simplicity (YAGNI) | PASS | Jinja2 templates, query-param flash messages, no session middleware |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-credential-setup/
+  plan.md              # This file
+  spec.md              # Feature specification (10 FRs, 3 user stories)
+  research.md          # Phase 0: Fernet, Docker secrets, PAT prefixes, SDK errors, FastAPI patterns
+  data-model.md        # Phase 1: StoredCredential, CredentialSource, ResolvedCredential, TokenValidationError
+  contracts/           # Phase 1: 4 module contracts
+    credential-store.md
+    credential-resolver.md
+    token-validator.md
+    web-routes.md
+  checklists/
+    requirements.md    # Spec quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+server/
+  credential_store.py     # NEW — Fernet encrypt/decrypt, file I/O
+  credential_resolver.py  # NEW — Multi-source resolution
+  token_validator.py      # NEW — Format check + Copilot SDK validation
+  web_routes.py           # NEW — FastAPI routes (/, /setup, /settings)
+  main.py                 # MODIFIED — mount routes, templates, static
+  mcp_server.py           # MODIFIED — use CredentialResolver in lifespan
+  copilot_client.py       # MODIFIED — add NoCredentialError(CopilotError) class; existing _startup_error flow reused
+  templates/              # NEW directory
+    base.html             # Layout: nav, flash, footer (monospace dark theme)
+    status.html           # GET / — source + masked token
+    setup.html            # GET /setup — PAT instructions + form
+    settings.html         # GET /settings — rotation form
+  static/                 # NEW directory
+    style.css             # Single CSS file (monospace dark theme)
+
+tests/
+  test_credential_store.py    # NEW
+  test_credential_resolver.py # NEW
+  test_token_validator.py     # NEW
+  test_web_routes.py          # NEW
+
+docker-compose.yml        # MODIFIED — volume, secrets, localhost binding
+Dockerfile                # MODIFIED — /data/ directory, cryptography dep
+requirements.txt          # MODIFIED — add cryptography>=44.0.0
+```
+
+**Structure Decision**: Flat module layout in `server/` consistent with existing codebase. No sub-packages — 4 new files alongside existing modules.
+
+## Integration Points
+
+### MCP Server (`mcp_server.py`)
+
+Current `_initialize_copilot()` reads `os.environ.get("GITHUB_TOKEN")` directly. Must change to:
+
+```python
+async def _initialize_copilot():
+    resolver = CredentialResolver(store=CredentialStore())
+    resolved = resolver.resolve()
+    if resolved is None:
+        # No credential source available — store a clear error for MCP tools
+        from server.copilot_client import NoCredentialError
+        _copilot._startup_error = NoCredentialError(
+            "No credential configured. Set up a token at localhost:8080, "
+            "provide GITHUB_TOKEN env var, or mount a Docker secret at "
+            "/run/secrets/github_token."
+        )
+        return
+    token = resolved.token
+    # ... rest unchanged
+```
+
+This satisfies FR-010 (credential resolution at MCP process startup).
+
+**No-credential behavior**: When `resolve()` returns `None`, the server still starts but sets a descriptive `_startup_error` on the Copilot client. The `start_review` tool will surface this error via the `_startup_error` check in `create_review_session()` at `copilot_client.py:131-132`. Other tools do not reach this check: `discuss` calls `send_followup()` → `send_review()` on an existing session; `get_review_summary` and `list_sessions` access only the session store. The error message directs users to all 3 credential setup methods. This replaces the current misleading message ("Copilot SDK is not available. Ensure github-copilot-sdk is installed and GITHUB_TOKEN is set.") which is inaccurate for the no-credential case.
+
+**Note**: `copilot_client.py` is minimally modified — add `NoCredentialError(CopilotError)` class (`retryable = False`) to the existing error hierarchy. The `_startup_error: CopilotError | None` type and `create_review_session()` check remain unchanged. The main change is in `mcp_server.py` which now sets a credential-specific `NoCredentialError` instead of silently returning.
+
+**MCP error handler contract**: `NoCredentialError` requires a dedicated `except` clause in each MCP tool's error handler chain (alongside `CopilotAuthError`, `CopilotUnavailableError`, etc.) to prevent it falling through to the generic `except Exception` → `"internal"` branch. Mapping:
+
+```python
+from server.copilot_client import NoCredentialError
+
+except NoCredentialError as e:
+    return {"error": "no_credential", "message": str(e), "retryable": False}
+```
+
+This handler is required only in `start_review` — the sole MCP tool whose code path reaches `CopilotReviewClient.create_review_session()` and thus `_startup_error`. The `discuss` tool calls `send_followup()` → `send_review()`, which operates on an existing session and never checks `_startup_error`; if no credential was configured, no session could have been created, so `discuss` would hit `session_not_found` first. The read-only tools (`get_review_summary`, `list_sessions`) only access the session store and never touch the Copilot client. The `"no_credential"` error code is distinct from `"unavailable"` (SDK/service down) and `"auth_failed"` (bad token) — it tells the orchestrating agent that no credential is configured and directs the user to the 3 setup methods. RED coverage for this handler goes in `tests/test_mcp_handlers.py` following the existing error-mapping test pattern (e.g., `test_auth_error_maps_correctly`).
+
+### Web Server (`main.py`)
+
+Current minimal app with only `/health`. Must add:
+- Jinja2Templates mount
+- StaticFiles mount for CSS
+- Include `web_routes` router
+- Instantiate shared `CredentialStore`, `CredentialResolver`, `TokenValidator`
+
+### Docker Configuration
+
+`docker-compose.yml` changes:
+- Port binding: `"8080:8080"` → `"127.0.0.1:8080:8080"` (FR-008)
+- Add named volume: `review-data:/data`
+- Add secrets section (optional, for Docker secret path)
+
+`Dockerfile` changes:
+- Add `RUN mkdir -p /data && chmod 700 /data`
+- `cryptography` already pulled via `requirements.txt`

--- a/specs/002-credential-setup/research.md
+++ b/specs/002-credential-setup/research.md
@@ -1,0 +1,79 @@
+# Research — 002-credential-setup
+
+## R-1: Fernet Encryption for Credential Storage
+
+**Decision**: Use `cryptography.fernet.Fernet` for at-rest encryption of stored PATs.
+
+**Rationale**: Fernet provides authenticated symmetric encryption (AES-128-CBC + HMAC-SHA256). It is the standard Python approach for encrypting sensitive data at rest. The `cryptography` library is actively maintained and widely used. The key is a 44-char URL-safe base64 string generated via `Fernet.generate_key()`.
+
+**Alternatives considered**:
+- AES-256-GCM via `cryptography.hazmat` — more flexible but more complex; Fernet's higher-level API is sufficient and less error-prone
+- `nacl.secret.SecretBox` (PyNaCl) — good library but adds a dependency; `cryptography` is already transitively available in many Python environments
+- External KMS (AWS KMS, HashiCorp Vault) — rejected per YAGNI constitution principle
+
+**Source**: [cryptography.io Fernet docs](https://cryptography.io/en/latest/fernet/)
+
+## R-2: Docker Secrets in Compose (Non-Swarm)
+
+**Decision**: Support Docker secrets via `file:` source in `docker-compose.yml`, mounted at `/run/secrets/github_token`.
+
+**Rationale**: Docker Compose (without Swarm) supports secrets as file mounts. No Docker-level encryption — the secret file is bind-mounted into the container. This is acceptable because: (1) our Fernet layer handles at-rest encryption for stored credentials, (2) Docker secrets still provide better hygiene than env vars by avoiding exposure through `/proc/*/environ`, crash dumps, and subprocess inheritance.
+
+**Alternatives considered**:
+- Docker Swarm secrets — real encryption but requires Swarm mode, which is not in scope
+- SOPS/age encrypted files — adds tooling complexity for limited benefit in single-user context
+
+**Source**: [Docker Compose secrets docs](https://docs.docker.com/compose/how-tos/use-secrets/)
+
+## R-3: Fine-Grained PAT Prefix Validation
+
+**Decision**: Validate token format by checking the `github_pat_` prefix. Reject `ghp_`, `gho_`, `ghs_`, `ghu_`.
+
+**Rationale**: GitHub uses distinct prefixes for each token type. Fine-grained PATs are 93 characters with the `github_pat_` prefix. Classic PATs use `ghp_` (40 chars after prefix). This is a well-documented pattern used by other tools (GitGuardian, GitHub's own token scanning).
+
+**Alternatives considered**:
+- Regex validation — overkill; prefix check is sufficient and simpler
+- GitHub API call to introspect token type — adds network latency and doesn't help with format validation
+
+**Source**: [GitHub token prefixes](https://gist.github.com/magnetikonline/073afe7909ffdd6f10ef06a00bc3bc88), [GitHub blog on fine-grained PATs](https://github.blog/security/application-security/introducing-fine-grained-personal-access-tokens-for-github/)
+
+## R-4: Copilot SDK Error Classification (Design-Phase Spike)
+
+**Decision**: Use two-step validation (GitHub API + Copilot SDK) to produce the 4 distinct error types required by FR-005.
+
+**Findings**: The existing `CopilotReviewClient._init_sdk()` in `server/copilot_client.py:199-225` classifies errors by checking `str(e).lower()` for `"auth"`, `"401"`, or `"403"`. Both expired tokens and permission-denied errors produce `CopilotAuthError`. The Copilot service uses HTTP 403 for multiple failure modes (expired tokens, missing permissions, missing subscription), making the status code unreliable for distinguishing auth from permission errors at the SDK level alone.
+
+**Design consequence**: FR-005 requires 4 distinct error messages. The Copilot SDK alone cannot distinguish auth from permission errors. We achieve best-effort distinction by adding a preliminary GitHub API check, with an honest confidence model:
+
+1. **Format error** — prefix check (local, no SDK needed)
+2. **Auth error** — `GET https://api.github.com/user` returns HTTP 401 → token is expired, revoked, or invalid. Only 401 maps to auth — other non-2xx responses (403 rate limit, 5xx server error) are treated as inconclusive and do NOT produce an auth classification.
+3. **Permission error** — GitHub API check confirmed auth (returned 2xx) AND `list_models()` fails → token authenticates to GitHub but cannot access Copilot. Message covers the most common causes: missing `copilot_requests` permission, no active Copilot subscription, or enterprise policy restriction.
+4. **SDK error** — `ImportError` or `CopilotUnavailableError` (SDK not installed / CLI won't start)
+5. **Inconclusive fallback** — If `GET /user` returned non-401 non-2xx (inconclusive) AND `list_models()` also fails, we cannot reliably distinguish auth from permission. In this case, `error_type="auth"` with a combined message covering both possibilities. This is honest — we don't overclaim.
+
+**Validation sequence**: format check → GitHub API auth probe → Copilot SDK access check. The GitHub API probe is diagnostic only (used for error classification), not a gate. If the probe is inconclusive, the Copilot check still runs.
+
+**Confidence model**:
+| GET /user result | list_models() result | Classification | Confidence |
+|-----------------|---------------------|----------------|------------|
+| 401 | (not called) | auth | High — 401 is definitive |
+| 2xx | fails (CopilotAuthError) | permission | High — token works for GitHub but not Copilot |
+| 2xx | fails (CopilotUnavailableError) | sdk | High — SDK problem, not token |
+| non-401 non-2xx | fails (CopilotAuthError) | auth (combined msg) | Low — cannot distinguish, honest fallback |
+| any | succeeds | (validation passes) | — |
+
+**Note on FR-005**: The spec says "Generic GitHub API validation (GET /user) is insufficient." Correct — GET /user is insufficient as the *sole* validation. It is used here as a *diagnostic probe* to disambiguate the error type, not as a replacement for the Copilot SDK check.
+
+**Coordinator decision (design round 4)**: Peter chose Option A — broaden FR-005's "permission error" from "specifically missing copilot_requests" to "cannot access Copilot" with verbose, diagnostic-style messages. All error messages must be chatty: list possible causes and include specific URLs (github.com/settings/tokens, github.com/settings/copilot) so users can self-diagnose. The 4-type taxonomy (format, auth, permission, sdk) is preserved.
+
+**Source**: [GitHub REST API — Get the authenticated user](https://docs.github.com/en/rest/users/users#get-the-authenticated-user). Returns 200 for valid tokens, 401 for expired/revoked, 403 for certain rate-limit or policy scenarios. The Copilot SDK uses 403 for multiple failure modes — see [community discussions](https://github.com/orgs/community/discussions/165646).
+
+## R-5: FastAPI + Jinja2 Web UI Patterns
+
+**Decision**: Use FastAPI's `Jinja2Templates` with `StaticFiles` mount. Server-rendered HTML forms with POST redirects (PRG pattern).
+
+**Rationale**: Constitution requires Jinja2, no React/SPA. FastAPI has built-in support for both. The PRG (Post/Redirect/Get) pattern prevents form resubmission on refresh. Flash messages via query parameters (simpler than session-based flash, aligns with YAGNI).
+
+**Alternatives considered**:
+- HTMX for partial page updates — adds a JS dependency; not needed for 3 simple pages
+- Session-based flash messages — requires session middleware; query params are simpler

--- a/specs/002-credential-setup/spec.md
+++ b/specs/002-credential-setup/spec.md
@@ -9,7 +9,7 @@
 
 ### User Story 1 - First-Time Setup via Web UI (Priority: P1)
 
-A colleague pulls the Docker image and runs `docker compose up -d`. They open `localhost:8080` in their browser. Since no credentials are stored, they see a setup wizard that guides them through creating a fine-grained GitHub PAT with the `copilot_requests` permission, pasting it, and verifying the connection. After successful setup, they are redirected to the main dashboard.
+A colleague pulls the Docker image and runs `docker compose up -d`. They open `localhost:8080` in their browser. Since no credentials are stored, they see a setup wizard that guides them through creating a fine-grained GitHub PAT with the `copilot_requests` permission, pasting it, and verifying the connection. After successful setup, they are redirected to a credential status page showing the active credential source and masked token.
 
 **Why this priority**: This is the primary path for non-technical colleagues to get started without using environment variables.
 
@@ -18,9 +18,12 @@ A colleague pulls the Docker image and runs `docker compose up -d`. They open `l
 **Acceptance Scenarios**:
 
 1. **Given** a fresh container with no stored credentials and no `GITHUB_TOKEN` env var, **When** a user opens `localhost:8080`, **Then** the setup wizard is displayed with instructions for creating a fine-grained PAT.
-2. **Given** the setup wizard is displayed, **When** the user pastes a valid fine-grained PAT and clicks "Save & Test Connection", **Then** the server validates the token, encrypts and stores it, and redirects to the dashboard.
-3. **Given** the setup wizard is displayed, **When** the user pastes an invalid token (classic PAT or expired), **Then** the server displays a specific error explaining why the token was rejected.
-4. **Given** the container is started with `GITHUB_TOKEN` env var set to a valid fine-grained PAT, **When** a user opens `localhost:8080`, **Then** the dashboard is displayed directly (setup wizard is skipped).
+2. **Given** the setup wizard is displayed, **When** the user pastes a valid fine-grained PAT and clicks "Save & Test Connection", **Then** the server validates the token format, validates Copilot access via `list_models()`, encrypts and stores the token, and redirects to the credential status page.
+3. **Given** the setup wizard is displayed, **When** the user pastes a token with a rejected prefix (e.g., `ghp_`, `gho_`, `ghs_`, `ghu_`) or an empty string, **Then** the server displays a format error identifying the specific rejected token type with remediation steps and a URL (e.g., "Classic PATs (ghp_) are not supported. AgentinaBox requires a fine-grained PAT with the copilot_requests permission. To create one: go to github.com/settings/tokens?type=beta, click 'Generate new token', and enable the copilot_requests permission under Account permissions."). The token is NOT stored.
+4. **Given** the setup wizard is displayed, **When** the user pastes a fine-grained PAT that is expired or revoked, **Then** the server displays an auth error with remediation steps (e.g., "Token authentication failed — the token appears to be expired or revoked. To fix this: go to github.com/settings/tokens, check if the token is still active, and create a new fine-grained PAT with the copilot_requests permission if needed."). The token is NOT stored.
+5. **Given** the setup wizard is displayed, **When** the user pastes a fine-grained PAT that authenticates to GitHub but cannot access Copilot, **Then** the server displays a permission error listing common causes and remediation steps (e.g., "Token authenticates to GitHub but cannot access Copilot. Common causes: (1) Missing permission — edit the token at github.com/settings/tokens and ensure copilot_requests is enabled. (2) No Copilot subscription — check your plan at github.com/settings/copilot. (3) Organization policy — your org admin may need to enable Copilot for your account."). The token is NOT stored.
+6. **Given** the setup wizard is displayed and the Copilot SDK is not installed or cannot start, **When** the user pastes a valid fine-grained PAT and clicks "Save & Test Connection", **Then** the server displays an SDK error explaining this is a container issue (not a token problem) with rebuild steps (e.g., "Copilot SDK unavailable — cannot validate token. This is a container configuration issue, not a problem with your token. The Copilot CLI may not be installed or failed to start. To fix this: run 'docker compose build --no-cache' to rebuild the container, then 'docker compose up -d' to restart it. If the issue persists, check the container logs with 'docker compose logs'. For Copilot CLI setup details, see docs.github.com/en/copilot."). The token is NOT stored.
+7. **Given** the container is started with `GITHUB_TOKEN` env var or a Docker secret, **When** a user opens `localhost:8080`, **Then** the credential status page is displayed directly (setup wizard is skipped).
 
 ---
 
@@ -34,9 +37,10 @@ A developer's token has expired or they want to switch accounts. They open the S
 
 **Acceptance Scenarios**:
 
-1. **Given** a valid token is stored, **When** a user opens the Settings page, **Then** the token is displayed masked (only last 4 characters visible) with a "Change" button.
+1. **Given** a valid token is stored, **When** a user opens the Settings page, **Then** the token is displayed masked (prefix + last 4 characters visible, e.g., `github_pat_...XXXX`) with a "Change" button, and the credential source is shown (stored, env var, or Docker secret).
 2. **Given** a user clicks "Change" and pastes a new valid token, **When** they click "Save & Test Connection", **Then** the old token is replaced with the new one (encrypted) and a success message is shown.
 3. **Given** a user pastes a new invalid token, **When** they click "Save & Test Connection", **Then** the old token is preserved and an error message explains the rejection.
+4. **Given** the active credential comes from a Docker secret or env var (not stored), **When** a user opens the Settings page, **Then** the credential source is shown as "Docker secret" or "Environment variable" and the change form is hidden with a note explaining that the token is managed externally.
 
 ---
 
@@ -50,41 +54,52 @@ A DevOps engineer configures the container for CI using Docker secrets instead o
 
 **Acceptance Scenarios**:
 
-1. **Given** a Docker secret is mounted and an env var is also set, **When** the server starts, **Then** the Docker secret is used (highest priority).
-2. **Given** an env var is set and no Docker secret is mounted, **When** the server starts, **Then** the env var is used.
-3. **Given** only a stored credential exists, **When** the server starts, **Then** the stored credential is decrypted and used.
+1. **Given** a Docker secret is mounted at `/run/secrets/github_token` and an env var `GITHUB_TOKEN` is also set, **When** the server starts, **Then** the Docker secret is used (highest priority).
+2. **Given** an env var `GITHUB_TOKEN` is set and no Docker secret is mounted, **When** the server starts, **Then** the env var is used.
+3. **Given** only a stored credential exists (no Docker secret, no env var), **When** the server starts, **Then** the stored credential is decrypted and used.
+4. **Given** no credential source is available (no Docker secret, no env var, no stored credential), **When** the server starts, **Then** the web UI redirects to the setup wizard and MCP tools return a clear "no credential configured" error.
 
 ---
 
 ### Edge Cases
 
-- What happens if the encryption key file is deleted but the encrypted credential remains?
-- What happens if the stored credential becomes invalid between container restarts?
-- How does the system behave if the Docker volume is shared between two container instances?
+- **Encryption key deleted, credential remains**: If the Fernet key file is deleted but the encrypted credential file still exists, the system MUST treat this as "no stored credential." The encrypted credential cannot be decrypted and MUST NOT be used. The system logs a warning (without exposing credential data) and falls back to the next available source or shows the setup wizard.
+- **Stored credential invalid between restarts**: If a stored credential becomes invalid (e.g., token expired or revoked on GitHub) between container restarts, the system does NOT re-validate stored credentials at startup. The failure is detected on first MCP tool invocation (during `CopilotReviewClient.start()`), and the tool returns a clear auth error. The user can then rotate the token via the Settings page.
+- **Docker volume shared between instances**: Sharing the `/data/` Docker volume between two running container instances is unsupported. The system uses atomic file writes (`os.replace()`) to minimize corruption risk, but does NOT implement locking or coordination between instances. If shared, behavior is undefined.
+- **Copilot SDK unavailable during validation**: If the Copilot SDK is not installed or the CLI process cannot start, token format validation still succeeds but Copilot validation fails with a verbose error explaining the issue is container-level, not token-level, with rebuild steps (see US1-AS6 for full example message). The token is NOT stored.
+- **Docker secret file has trailing whitespace/newline**: Docker secret files often contain a trailing newline. The system MUST strip leading and trailing whitespace from Docker secret file contents before use.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: System MUST persist credentials encrypted at rest in a Docker volume, never in plaintext
-- **FR-002**: System MUST accept credentials via three methods in priority order: Docker secret > environment variable > stored credential. Docker secrets are the preferred method for shared or production-like environments; environment variables are a convenience path for local development
-- **FR-003**: System MUST reject classic PATs and only accept fine-grained PATs with `copilot_requests` permission
-- **FR-004**: System MUST provide a web-based setup wizard at `localhost:8080` when no credentials are configured
-- **FR-005**: System MUST validate tokens by making a real Copilot SDK call (e.g., `list_models()`) before storing them. Generic GitHub API validation (`GET /user`) is insufficient — a token can have valid GitHub scopes but lack the Copilot permission or policy access needed for actual reviews. If the Copilot call fails, the token MUST be rejected with a specific error explaining that the token works for GitHub but not for Copilot
-- **FR-006**: System MUST provide a Settings page to view (masked) and rotate stored tokens
-- **FR-007**: System MUST never expose plaintext tokens in logs, API responses, or web UI output
-- **FR-008**: System MUST bind the web UI to localhost only (not exposed to the network)
+- **FR-001**: System MUST persist credentials encrypted at rest using Fernet symmetric encryption (AES-128-CBC + HMAC-SHA256) in a Docker named volume, never in plaintext. The Fernet key MUST be auto-generated on first use and persisted in the same volume. If the Fernet key is lost, the system MUST treat the encrypted credential as unavailable and require re-entry.
+- **FR-002**: System MUST accept credentials via three methods in priority order: Docker secret (read from `/run/secrets/github_token`) > environment variable (`GITHUB_TOKEN`) > stored credential (decrypted from volume). Docker secrets are the preferred method for shared or production-like environments; environment variables are a convenience path for local development. The system MUST resolve the credential source fresh on each process startup.
+- **FR-003**: System MUST reject tokens with these prefixes: `ghp_` (classic PAT), `gho_` (OAuth app token), `ghs_` (GitHub App server-to-server token), `ghu_` (GitHub App user-to-server token). System MUST only accept tokens with the `github_pat_` prefix (fine-grained PAT). Error messages MUST identify the specific rejected token type and explain what is expected.
+- **FR-004**: System MUST provide a web-based setup wizard at `localhost:8080` when no credentials are configured via any source. The setup wizard MUST include step-by-step instructions for creating a fine-grained PAT with the `copilot_requests` permission.
+- **FR-005**: System MUST validate tokens by making a real Copilot SDK call (`list_models()`) before storing them. Generic GitHub API validation (`GET /user`) is insufficient as the sole check — a token can have valid GitHub scopes but lack the Copilot permission or policy access needed for actual reviews. Validation failures MUST produce distinct, verbose, actionable error messages for each failure mode. Messages MUST list possible causes and include specific URLs and remediation steps the user can follow to self-diagnose:
+  - **Format error**: Token has a rejected prefix or is empty → identify the rejected type, explain the expected format, and link to token creation at `github.com/settings/tokens?type=beta`
+  - **Auth error**: Token is expired, revoked, or otherwise fails GitHub authentication → link to `github.com/settings/tokens` and advise creating a new token with step-by-step instructions
+  - **Permission error**: Token authenticates to GitHub but cannot access Copilot (e.g., missing `copilot_requests` permission, no Copilot subscription, or org policy restriction) → list all common causes with remediation steps and URLs for each (`github.com/settings/tokens`, `github.com/settings/copilot`)
+  - **SDK error**: Copilot SDK is not installed or CLI process cannot start → identify the SDK as the problem (not the token), provide rebuild commands (`docker compose build --no-cache`), suggest checking container logs, and link to Copilot documentation (`docs.github.com/en/copilot`)
+- **FR-006**: System MUST provide a Settings page to view (masked) and rotate stored tokens. The masked display MUST show the token prefix and last 4 characters only (e.g., `github_pat_...XXXX`). When the active credential comes from a Docker secret or env var, the Settings page MUST show the source and disable the rotation form.
+- **FR-007**: System MUST never expose plaintext tokens in logs, API responses, or web UI output. Error messages from token validation MUST NOT echo back the submitted token value. Log messages about credential resolution MUST log the source type (e.g., "docker_secret", "env_var", "stored") but never the token value.
+- **FR-008**: System MUST bind the web UI port to localhost only via Docker port mapping (`127.0.0.1:8080:8080`). The web server inside the container MAY bind to all interfaces (`0.0.0.0`) since Docker's port mapping restricts host-side access.
+- **FR-009**: System MUST provide a credential status page at the root URL (`/`) showing the active credential source and masked token. The page MUST NOT claim connection status or validity — credential validation only occurs during token setup/rotation and on first MCP use, not at page load. This page is owned by this spec and serves as the post-setup redirect destination. Spec 003 (Review Dashboard) may later expand or replace this page, but this spec MUST NOT depend on spec 003 for the post-setup experience.
+- **FR-010**: Credential resolution for MCP MUST occur at MCP process startup (within the lifespan context). Each MCP connection via `docker exec` starts a fresh process and resolves the latest available credential. Token rotation via the web UI takes effect on the next MCP connection, not within an active session. Long-lived MCP sessions (if a client holds the stdio pipe open) use the token that was active when the session started; this is expected behavior, consistent with how environment variables bind at process start.
 
 ### Key Entities
 
 - **Credential**: The stored GitHub fine-grained PAT. Encrypted at rest with a Fernet key. Has a creation date and last-validated timestamp.
-- **Credential Source**: The origin of the active credential (env var, Docker secret, or stored). Determined at startup by priority order.
+- **Credential Source**: The origin of the active credential. One of: `docker_secret`, `env_var`, `stored`, `none`. Determined at startup by priority order (FR-002).
+- **Fernet Key**: A 44-character URL-safe base64 symmetric key used for credential encryption/decryption. Auto-generated on first use, persisted in the Docker volume. Loss of this key invalidates all stored credentials.
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
 - **SC-001**: A new user can go from opening `localhost:8080` to a validated, stored credential in under 2 minutes
-- **SC-002**: Token rotation completes without downtime (no container restart needed)
-- **SC-003**: Credentials are never exposed in any output visible to the user or in container logs
-- **SC-004**: The system correctly prioritizes credential sources on every startup
+- **SC-002**: Token rotation completes without downtime (no container restart needed). The next MCP connection (new `docker exec` invocation) after rotation uses the new token. Active MCP sessions continue with the token they started with.
+- **SC-003**: Credentials are never exposed in any output visible to the user or in container logs. Verified by grep of all log output and HTTP response bodies.
+- **SC-004**: The system correctly prioritizes credential sources on every startup. Verified by testing all 4 combinations (Docker secret + env var, env var only, stored only, none).
+- **SC-005**: Invalid tokens (classic PAT, missing Copilot permission, expired) are rejected with specific, actionable error messages that help the user self-correct.

--- a/specs/002-credential-setup/tasks.md
+++ b/specs/002-credential-setup/tasks.md
@@ -1,0 +1,191 @@
+# Tasks: Credential Setup & Management
+
+**Input**: Design documents from `/specs/002-credential-setup/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Organization**: Tasks are grouped by user story. TDD is mandatory per constitution — write failing tests before implementation (RED-GREEN-REFACTOR).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Project Configuration)
+
+**Purpose**: Docker configuration, dependencies, and UI infrastructure needed before any module work.
+
+- [x] T001 Update `requirements.txt` — add `cryptography>=44.0.0`
+- [ ] T002 [P] Update `Dockerfile` — add `RUN mkdir -p /data && chmod 700 /data`
+- [ ] T003 [P] Update `docker-compose.yml` — add named volume `review-data:/data`, change port to `127.0.0.1:8080:8080` (FR-008), add secrets section
+- [ ] T004 [P] Create `server/templates/base.html` — layout template with nav, flash message area, footer; monospace dark theme; links to style.css
+- [ ] T005 [P] Create `server/static/style.css` — single CSS file, monospace dark theme per constitution
+
+**Checkpoint**: Infrastructure ready — module implementation can begin.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core credential storage and resolution modules that ALL user stories depend on.
+
+**CRITICAL**: No user story work can begin until CredentialStore and CredentialResolver are implemented.
+
+### CredentialStore (TDD)
+
+- [ ] T006 Write failing tests for `CredentialStore` in `tests/test_credential_store.py` (RED). Cover: `store()` creates key + encrypted file + metadata, `load()` decrypts, `load()` returns None on missing key (FR-001 key loss), `load()` returns None on missing file, `delete()` removes credential files but keeps key, `has_stored_credential()`, `get_metadata()`, `update_last_validated()`, atomic writes via `os.replace()`
+- [ ] T007 Implement `CredentialStore` in `server/credential_store.py` (GREEN). Follow contract at `specs/002-credential-setup/contracts/credential-store.md`. Fernet key at `/data/.fernet_key` (chmod 600), encrypted token at `/data/credentials.enc`, metadata at `/data/credential_meta.json`. Use `os.replace()` for atomic writes.
+
+### CredentialResolver (TDD)
+
+- [ ] T008 Write failing tests for `CredentialResolver` in `tests/test_credential_resolver.py` (RED). Cover: Docker secret > env var > stored priority (FR-002), whitespace stripping on all sources (edge case), returns None when no source available, `get_source()` returns correct `CredentialSource` enum, logging source type without token value (FR-007)
+- [ ] T009 Implement `CredentialResolver` in `server/credential_resolver.py` (GREEN). Follow contract at `specs/002-credential-setup/contracts/credential-resolver.md`. Priority: Docker secret (`/run/secrets/github_token`) > env var (`GITHUB_TOKEN`) > stored credential. Strip whitespace from all sources. No caching — fresh on each `resolve()` call.
+
+**Checkpoint**: Foundation ready — user story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — First-Time Setup via Web UI (Priority: P1) MVP
+
+**Goal**: New user opens localhost:8080, sees setup wizard, pastes PAT, gets validated and stored, redirected to status page.
+
+**Independent Test**: Start container with no credentials, open localhost:8080, verify wizard appears, paste valid PAT, verify redirect to status page.
+
+### Tests for US1 (RED — write first, must fail)
+
+- [ ] T010 Write failing tests for `TokenValidator` in `tests/test_token_validator.py` (RED). Cover: `validate_format()` accepts `github_pat_` prefix, rejects `ghp_`/`gho_`/`ghs_`/`ghu_`/empty with specific error messages and URLs per contract; `_probe_github_auth()` raises auth error on 401 with verbose message and URL per contract, returns True on 2xx, returns None on other status codes; `validate_copilot_access()` raises permission error with verbose message and URL per contract when `github_auth_confirmed=True` and Copilot fails, raises auth (combined) with verbose message and URL when `github_auth_confirmed=None` and Copilot fails, raises sdk error with verbose message and URL per contract on ImportError/CopilotUnavailableError; `validate()` orchestrates all three steps correctly. All 4 error types (format, auth, permission, sdk) must assert message content and remediation URLs matching the accepted templates in `contracts/token-validator.md` (AC-3)
+- [ ] T011 [P] Write failing tests for setup + status web routes in `tests/test_web_routes.py` (RED). Cover: GET `/` redirects to `/setup` when no credential (AC-1), GET `/` renders status page with source + masked token when credential exists, GET `/setup` renders wizard when no credential (AC-1), GET `/setup` redirects to `/` when credential exists, POST `/setup` with valid token → validates + stores + redirects to `/?msg=saved` (AC-2), POST `/setup` with invalid token → re-renders setup with error message (AC-3), `mask_token()` helper shows prefix + last 4 chars
+
+### Implementation for US1 (GREEN)
+
+- [ ] T012 Implement `TokenValidator` in `server/token_validator.py` (GREEN). Follow contract at `specs/002-credential-setup/contracts/token-validator.md`. Three-step validate: format → `_probe_github_auth()` (urllib.request via asyncio.to_thread) → `validate_copilot_access()` (temporary CopilotReviewClient). Verbose error messages with URLs per error messages section of contract.
+- [ ] T013 [P] Create `server/templates/setup.html` — extends base.html; PAT creation instructions (step-by-step: go to github.com/settings/tokens?type=beta, generate token, enable copilot_requests); token input form with "Save & Test Connection" button; error display area
+- [ ] T014 [P] Create `server/templates/status.html` — extends base.html; shows credential source and masked token; flash message display; link to Settings page; MUST NOT claim connection status (FR-009)
+- [ ] T015 Implement setup + status routes in `server/web_routes.py` (GREEN). Follow contract at `specs/002-credential-setup/contracts/web-routes.md`. GET `/` (redirect to /setup if no credential, else render status), GET `/setup`, POST `/setup` (validate → store → redirect with PRG pattern). Include `mask_token()` helper.
+- [ ] T016 Update `server/main.py` — mount `Jinja2Templates("server/templates")`, mount `StaticFiles` for `server/static`, include `web_routes` router, instantiate shared `CredentialStore`/`CredentialResolver`/`TokenValidator`
+
+### MCP Credential Integration (TDD)
+
+- [ ] T017 Write failing tests for MCP credential integration in `tests/test_mcp_server_config.py` (RED). Extend existing MCP test surface to cover: `_initialize_copilot()` uses `CredentialResolver.resolve()` instead of `os.environ.get("GITHUB_TOKEN")`, `_startup_error` set to `NoCredentialError` with message listing all 3 credential methods when `resolve()` returns None (FR-010), after storing new token via `CredentialStore.store()` next MCP connection picks up updated credential (AC-5 rotation). Also add `NoCredentialError` → `"no_credential"` error-mapping test in `tests/test_mcp_handlers.py` for the `start_review` handler only (following existing pattern at `test_auth_error_maps_correctly`), verifying the error does NOT fall through to `"internal"`. Note: `discuss` does not need this test — its code path (`send_followup()` → `send_review()`) never checks `_startup_error`; if no credential was configured, no session exists, so `discuss` hits `session_not_found` first
+- [ ] T018 Update `server/mcp_server.py` and `server/copilot_client.py` (GREEN) — first add `NoCredentialError(CopilotError)` class to `server/copilot_client.py` (extends existing hierarchy, `retryable = False`, fits `_startup_error: CopilotError | None` type). Then in `server/mcp_server.py`: (a) replace `os.environ.get("GITHUB_TOKEN")` in `_initialize_copilot()` with `CredentialResolver.resolve()`, setting `_startup_error` as `NoCredentialError` when `resolve()` returns None (FR-010); (b) add `except NoCredentialError` handler to the `start_review` tool handler only, mapping to `{"error": "no_credential", "message": str(e), "retryable": False}` — placed alongside existing `CopilotAuthError`/`CopilotUnavailableError` handlers, before the generic `except Exception` branch. Note: `discuss` does not need this handler — its path (`send_followup()` → `send_review()`) never checks `_startup_error`; `get_review_summary` and `list_sessions` are read-only (session store only)
+
+**Checkpoint**: US1 complete — fresh container shows setup wizard, accepts valid PAT, rejects invalid tokens with verbose errors, redirects to status page. MCP returns clear error when no credential configured.
+
+---
+
+## Phase 4: User Story 2 — Rotate or Change Token (Priority: P2)
+
+**Goal**: User with existing token can view masked token on Settings page and rotate to a new token without container restart.
+
+**Independent Test**: Set up a token, open Settings page, change to a new valid token, verify next MCP connection uses new token.
+
+### Tests for US2 (RED)
+
+- [ ] T019 Extend tests in `tests/test_web_routes.py` for settings/rotation routes (RED). Cover: GET `/settings` shows masked token + source + change form when source is `stored` (US2-AS1), GET `/settings` disables form when source is `docker_secret` or `env_var` (US2-AS4), POST `/settings/rotate` with valid token → replaces old + redirects to `/settings?msg=rotated` (US2-AS2, AC-5), POST `/settings/rotate` with invalid token → preserves old token + shows error (US2-AS3), POST `/settings/rotate` rejected when source is not `stored`
+
+### Implementation for US2 (GREEN)
+
+- [ ] T020 Create `server/templates/settings.html` — extends base.html; shows masked token and credential source; change form (visible only when `can_rotate` is True); externally-managed explanation when Docker secret/env var; flash message display
+- [ ] T021 Implement settings/rotation routes in `server/web_routes.py` (GREEN). GET `/settings` (render with source, masked_token, can_rotate flag), POST `/settings/rotate` (check source is stored → validate → store → redirect with PRG pattern; reject if externally managed)
+
+**Checkpoint**: US2 complete — stored tokens can be rotated via Settings page. External credentials show source with disabled form.
+
+---
+
+## Phase 5: User Story 3 — Multiple Credential Sources (Priority: P3)
+
+**Goal**: System correctly discovers and prioritizes credentials from Docker secret, env var, and stored credential.
+
+**Independent Test**: Provide credentials via Docker secret while stored credential exists; verify Docker secret takes precedence.
+
+- [ ] T022 [US3] Write integration tests for credential source priority in `tests/test_credential_resolver.py` (extend). Cover all 4 combinations from SC-004: Docker secret + env var → Docker secret wins (US3-AS1), env var only → env var used (US3-AS2), stored only → stored used (US3-AS3), none → returns None (US3-AS4). Note: cross-surface assertions (web UI redirect when no source, MCP `start_review` error response) are already covered by T011 (`tests/test_web_routes.py`) and T017 (`tests/test_mcp_handlers.py`) respectively — T022 focuses solely on resolver-level source priority.
+- [ ] T023 [P] [US3] Write test for Docker secret trailing whitespace stripping in `tests/test_credential_resolver.py` — verify `.strip()` on Docker secret file contents (edge case)
+
+**Checkpoint**: All credential source combinations verified. Priority order correct.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Security hardening, edge cases, and end-to-end verification.
+
+- [ ] T024 [P] Security audit — grep all code for token value exposure (FR-007, SC-003). Verify: no token in log statements, no token in HTTP response bodies, no token in error messages, `mask_token()` used consistently. Check error messages from TokenValidator don't echo submitted token.
+- [ ] T025 [P] Edge case tests — add tests for: Fernet key loss with existing credential file (AC-9), decryption failure (corrupted file), Copilot SDK unavailable during validation (edge case), concurrent store/load (atomic writes), stored credential becomes invalid between restarts (EC-2: verify MCP returns auth error on first use, not startup error)
+- [ ] T026 Docker build and compose validation — `docker compose build --no-cache`, verify container starts, `/data/` exists with correct permissions, `127.0.0.1:8080` binding works, named volume persists across restarts
+- [ ] T027 End-to-end AC verification — manually verify all 9 acceptance criteria from task.md with evidence
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on T001 (cryptography in requirements.txt) — BLOCKS all user stories
+- **Phase 3 (US1)**: Depends on Phase 2 completion (CredentialStore + CredentialResolver)
+- **Phase 4 (US2)**: Depends on Phase 3 completion (web routes infrastructure, TokenValidator)
+- **Phase 5 (US3)**: Depends on Phase 2 completion (CredentialResolver). Can run in parallel with Phase 3 and Phase 4.
+- **Phase 6 (Polish)**: Depends on Phase 4 and Phase 5 completion (all features implemented)
+
+### Within-Phase Dependencies
+
+**Phase 2**:
+```
+T006 (store tests) → T007 (store impl) → T009 (resolver impl)
+T008 (resolver tests) can parallel with T006/T007 (mock CredentialStore in tests)
+```
+
+**Phase 3**:
+```
+T010 (validator tests) → T012 (validator impl) → T015 (web routes impl)
+T011 (route tests) can parallel with T010
+T013, T014 (templates) can parallel with T010-T012
+T015 depends on T012 (TokenValidator) + T013/T014 (templates)
+T016 (main.py) depends on T015
+T017 (MCP tests) depends on T009 (CredentialResolver)
+T017 (MCP tests) → T018 (MCP impl)
+```
+
+**Phase 4**:
+```
+T019 (settings tests) → T020 (template) + T021 (routes impl)
+```
+
+### Parallel Opportunities
+
+- **Phase 1**: T002, T003, T004, T005 can all run in parallel
+- **Phase 2**: T006+T007 (store) and T008 (resolver tests) can run in parallel
+- **Phase 3**: T010 (validator tests) and T011 (route tests) can run in parallel; T013 and T014 (templates) can run in parallel with test/impl work
+- **Phase 5**: T022 and T023 can run in parallel; Phase 5 can run in parallel with Phase 3 and Phase 4
+- **Phase 6**: T024 and T025 can run in parallel
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Phase 1: Setup (T001-T005)
+2. Phase 2: Foundational — CredentialStore + CredentialResolver (T006-T009)
+3. Phase 3: US1 — Setup wizard + status page + MCP integration (T010-T018)
+4. **STOP and VALIDATE**: Fresh container → setup wizard → paste PAT → status page works
+
+### Full Delivery
+
+5. Phase 4: US2 — Token rotation via Settings page (T019-T021)
+6. Phase 5: US3 — Priority order integration tests (T022-T023)
+7. Phase 6: Polish — security audit, edge cases, Docker validation, AC verification (T024-T027)
+
+---
+
+## Notes
+
+- TDD is MANDATORY per constitution — every module has RED tests before GREEN implementation
+- [P] tasks = different files, no shared state
+- All error messages must be verbose with URLs per coordinator decision (Option A)
+- `mask_token()` must be used everywhere tokens are displayed (FR-007)
+- Web routes use PRG pattern — POST validates + stores, then redirects (R-5)
+- Flash messages via query param `?msg=` (YAGNI, no session middleware)
+- Commit after each task or logical TDD cycle (RED-GREEN-REFACTOR)

--- a/tests/test_credential_resolver.py
+++ b/tests/test_credential_resolver.py
@@ -1,0 +1,413 @@
+"""Tests for CredentialResolver — T008, T022, T023 (RED).
+
+Covers: Docker secret > env var > stored priority (FR-002), whitespace stripping,
+returns None when no source, get_source(), logging source without token (FR-007),
+SC-004 integration tests for all 4 source priority combinations (T022),
+Docker secret trailing whitespace stripping (T023).
+Per contract: specs/002-credential-setup/contracts/credential-resolver.md
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from server.credential_resolver import CredentialResolver, CredentialSource, ResolvedCredential
+
+
+@pytest.fixture
+def mock_store():
+    store = MagicMock()
+    store.load.return_value = None
+    return store
+
+
+@pytest.fixture
+def resolver(mock_store, tmp_path):
+    """Resolver with non-existent Docker secret path and mocked store."""
+    return CredentialResolver(
+        store=mock_store,
+        docker_secret_path=str(tmp_path / "github_token"),
+    )
+
+
+class TestResolve:
+    def test_docker_secret_highest_priority(self, mock_store, tmp_path, monkeypatch):
+        """FR-002: Docker secret > env var > stored."""
+        secret_path = tmp_path / "github_token"
+        secret_path.write_text("github_pat_from_docker_secret")
+        monkeypatch.setenv("GITHUB_TOKEN", "github_pat_from_env")
+        mock_store.load.return_value = "github_pat_from_stored"
+
+        resolver = CredentialResolver(store=mock_store, docker_secret_path=str(secret_path))
+        result = resolver.resolve()
+
+        assert result is not None
+        assert result.token == "github_pat_from_docker_secret"
+        assert result.source == CredentialSource.DOCKER_SECRET
+
+    def test_env_var_second_priority(self, mock_store, tmp_path, monkeypatch):
+        """FR-002: env var used when no Docker secret."""
+        monkeypatch.setenv("GITHUB_TOKEN", "github_pat_from_env")
+        mock_store.load.return_value = "github_pat_from_stored"
+
+        resolver = CredentialResolver(
+            store=mock_store,
+            docker_secret_path=str(tmp_path / "nonexistent"),
+        )
+        result = resolver.resolve()
+
+        assert result is not None
+        assert result.token == "github_pat_from_env"
+        assert result.source == CredentialSource.ENV_VAR
+
+    def test_stored_credential_third_priority(self, mock_store, tmp_path, monkeypatch):
+        """FR-002: stored credential used when no Docker secret or env var."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        mock_store.load.return_value = "github_pat_from_stored"
+
+        resolver = CredentialResolver(
+            store=mock_store,
+            docker_secret_path=str(tmp_path / "nonexistent"),
+        )
+        result = resolver.resolve()
+
+        assert result is not None
+        assert result.token == "github_pat_from_stored"
+        assert result.source == CredentialSource.STORED
+
+    def test_returns_none_when_no_source(self, resolver, monkeypatch):
+        """No source available → returns None."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        result = resolver.resolve()
+        assert result is None
+
+    def test_whitespace_stripping_docker_secret(self, mock_store, tmp_path, monkeypatch):
+        """Edge case: Docker secrets often have trailing newlines."""
+        secret_path = tmp_path / "github_token"
+        secret_path.write_text("  github_pat_test1234  \n")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        resolver = CredentialResolver(store=mock_store, docker_secret_path=str(secret_path))
+        result = resolver.resolve()
+
+        assert result is not None
+        assert result.token == "github_pat_test1234"
+
+    def test_whitespace_stripping_env_var(self, resolver, monkeypatch):
+        """Whitespace stripping on env var."""
+        monkeypatch.setenv("GITHUB_TOKEN", "  github_pat_test1234  ")
+        result = resolver.resolve()
+        assert result is not None
+        assert result.token == "github_pat_test1234"
+
+    def test_whitespace_stripping_stored(self, mock_store, tmp_path, monkeypatch):
+        """Whitespace stripping on stored credential."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        mock_store.load.return_value = "  github_pat_test1234  "
+
+        resolver = CredentialResolver(
+            store=mock_store,
+            docker_secret_path=str(tmp_path / "nonexistent"),
+        )
+        result = resolver.resolve()
+
+        assert result is not None
+        assert result.token == "github_pat_test1234"
+
+    def test_empty_docker_secret_skipped(self, mock_store, tmp_path, monkeypatch):
+        """Empty Docker secret file (after stripping) → skip to next source."""
+        secret_path = tmp_path / "github_token"
+        secret_path.write_text("   \n")
+        monkeypatch.setenv("GITHUB_TOKEN", "github_pat_from_env")
+
+        resolver = CredentialResolver(store=mock_store, docker_secret_path=str(secret_path))
+        result = resolver.resolve()
+
+        assert result is not None
+        assert result.source == CredentialSource.ENV_VAR
+
+    def test_empty_env_var_skipped(self, resolver, monkeypatch):
+        """Empty env var → skip to stored."""
+        monkeypatch.setenv("GITHUB_TOKEN", "")
+        result = resolver.resolve()
+        assert result is None
+
+
+class TestGetSource:
+    def test_returns_docker_secret(self, mock_store, tmp_path, monkeypatch):
+        secret_path = tmp_path / "github_token"
+        secret_path.write_text("github_pat_test1234")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        resolver = CredentialResolver(store=mock_store, docker_secret_path=str(secret_path))
+        assert resolver.get_source() == CredentialSource.DOCKER_SECRET
+
+    def test_returns_env_var(self, resolver, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "github_pat_test1234")
+        assert resolver.get_source() == CredentialSource.ENV_VAR
+
+    def test_returns_stored(self, mock_store, tmp_path, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        mock_store.load.return_value = "github_pat_test1234"
+        resolver = CredentialResolver(
+            store=mock_store,
+            docker_secret_path=str(tmp_path / "nonexistent"),
+        )
+        assert resolver.get_source() == CredentialSource.STORED
+
+    def test_returns_none(self, resolver, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        assert resolver.get_source() == CredentialSource.NONE
+
+
+class TestSourcePriorityIntegration:
+    """T022: SC-004 integration tests — all 4 credential source combinations.
+
+    These tests explicitly verify the priority order documented in SC-004:
+    1. Docker secret + env var → Docker secret wins (US3-AS1)
+    2. env var only → env var used (US3-AS2)
+    3. stored only → stored used (US3-AS3)
+    4. none → returns None (US3-AS4)
+    """
+
+    def test_docker_secret_beats_env_var(self, mock_store, tmp_path, monkeypatch):
+        """SC-004 combo 1 (US3-AS1): Docker secret + env var → Docker secret wins."""
+        secret_path = tmp_path / "github_token"
+        secret_path.write_text("github_pat_from_docker")
+        monkeypatch.setenv("GITHUB_TOKEN", "github_pat_from_env")
+        # No stored credential
+        mock_store.load.return_value = None
+
+        resolver = CredentialResolver(store=mock_store, docker_secret_path=str(secret_path))
+        result = resolver.resolve()
+
+        assert result is not None
+        assert result.token == "github_pat_from_docker"
+        assert result.source == CredentialSource.DOCKER_SECRET
+        # get_source() agrees
+        assert resolver.get_source() == CredentialSource.DOCKER_SECRET
+
+    def test_env_var_only(self, mock_store, tmp_path, monkeypatch):
+        """SC-004 combo 2 (US3-AS2): env var only (no Docker secret, no stored) → env var used."""
+        monkeypatch.setenv("GITHUB_TOKEN", "github_pat_from_env")
+        mock_store.load.return_value = None
+
+        resolver = CredentialResolver(
+            store=mock_store,
+            docker_secret_path=str(tmp_path / "nonexistent"),
+        )
+        result = resolver.resolve()
+
+        assert result is not None
+        assert result.token == "github_pat_from_env"
+        assert result.source == CredentialSource.ENV_VAR
+        assert resolver.get_source() == CredentialSource.ENV_VAR
+
+    def test_stored_only(self, mock_store, tmp_path, monkeypatch):
+        """SC-004 combo 3 (US3-AS3): stored only (no Docker secret, no env var) → stored used."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        mock_store.load.return_value = "github_pat_from_stored"
+
+        resolver = CredentialResolver(
+            store=mock_store,
+            docker_secret_path=str(tmp_path / "nonexistent"),
+        )
+        result = resolver.resolve()
+
+        assert result is not None
+        assert result.token == "github_pat_from_stored"
+        assert result.source == CredentialSource.STORED
+        assert resolver.get_source() == CredentialSource.STORED
+
+    def test_no_source_returns_none(self, mock_store, tmp_path, monkeypatch):
+        """SC-004 combo 4 (US3-AS4): no credential source → returns None."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        mock_store.load.return_value = None
+
+        resolver = CredentialResolver(
+            store=mock_store,
+            docker_secret_path=str(tmp_path / "nonexistent"),
+        )
+        result = resolver.resolve()
+
+        assert result is None
+        assert resolver.get_source() == CredentialSource.NONE
+
+
+class TestDockerSecretWhitespaceStripping:
+    """T023: Docker secret trailing whitespace stripping edge cases.
+
+    Docker secret files commonly have trailing newlines appended by the
+    filesystem or by tooling that creates them. The resolver MUST strip
+    all leading/trailing whitespace before use.
+    """
+
+    def test_trailing_newline_stripped(self, mock_store, tmp_path, monkeypatch):
+        """Single trailing newline (most common Docker secret artifact)."""
+        secret_path = tmp_path / "github_token"
+        secret_path.write_text("github_pat_test1234\n")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        resolver = CredentialResolver(store=mock_store, docker_secret_path=str(secret_path))
+        result = resolver.resolve()
+
+        assert result is not None
+        assert result.token == "github_pat_test1234"
+        assert result.source == CredentialSource.DOCKER_SECRET
+
+    def test_multiple_trailing_newlines_stripped(self, mock_store, tmp_path, monkeypatch):
+        """Multiple trailing newlines stripped."""
+        secret_path = tmp_path / "github_token"
+        secret_path.write_text("github_pat_test1234\n\n\n")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        resolver = CredentialResolver(store=mock_store, docker_secret_path=str(secret_path))
+        result = resolver.resolve()
+
+        assert result is not None
+        assert result.token == "github_pat_test1234"
+
+    def test_leading_and_trailing_whitespace_stripped(self, mock_store, tmp_path, monkeypatch):
+        """Both leading and trailing whitespace/newlines stripped."""
+        secret_path = tmp_path / "github_token"
+        secret_path.write_text("  \t github_pat_test1234 \t \n")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        resolver = CredentialResolver(store=mock_store, docker_secret_path=str(secret_path))
+        result = resolver.resolve()
+
+        assert result is not None
+        assert result.token == "github_pat_test1234"
+
+    def test_whitespace_only_secret_skipped(self, mock_store, tmp_path, monkeypatch):
+        """Whitespace-only Docker secret file is treated as empty/missing."""
+        secret_path = tmp_path / "github_token"
+        secret_path.write_text("  \n\t\n  ")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        mock_store.load.return_value = None
+
+        resolver = CredentialResolver(store=mock_store, docker_secret_path=str(secret_path))
+        result = resolver.resolve()
+
+        assert result is None
+
+
+class TestResolverLogging:
+    """L-1: Verify resolver logs source type without exposing token values (SC-003, FR-007)."""
+
+    TOKEN = "github_pat_SECRETVALUE1234567890"
+
+    def test_docker_secret_logs_source(self, mock_store, tmp_path, monkeypatch, caplog):
+        secret_path = tmp_path / "github_token"
+        secret_path.write_text(self.TOKEN)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        resolver = CredentialResolver(store=mock_store, docker_secret_path=str(secret_path))
+        with caplog.at_level(logging.INFO, logger="server.credential_resolver"):
+            resolver.resolve()
+
+        assert "docker_secret" in caplog.text
+        assert self.TOKEN not in caplog.text
+
+    def test_env_var_logs_source(self, mock_store, tmp_path, monkeypatch, caplog):
+        monkeypatch.setenv("GITHUB_TOKEN", self.TOKEN)
+
+        resolver = CredentialResolver(
+            store=mock_store,
+            docker_secret_path=str(tmp_path / "nonexistent"),
+        )
+        with caplog.at_level(logging.INFO, logger="server.credential_resolver"):
+            resolver.resolve()
+
+        assert "env_var" in caplog.text
+        assert self.TOKEN not in caplog.text
+
+    def test_stored_logs_source(self, mock_store, tmp_path, monkeypatch, caplog):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        mock_store.load.return_value = self.TOKEN
+
+        resolver = CredentialResolver(
+            store=mock_store,
+            docker_secret_path=str(tmp_path / "nonexistent"),
+        )
+        with caplog.at_level(logging.INFO, logger="server.credential_resolver"):
+            resolver.resolve()
+
+        assert "stored" in caplog.text
+        assert self.TOKEN not in caplog.text
+
+    def test_no_source_logs_message(self, resolver, monkeypatch, caplog):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        with caplog.at_level(logging.INFO, logger="server.credential_resolver"):
+            resolver.resolve()
+
+        assert "No credential source available" in caplog.text
+        assert self.TOKEN not in caplog.text
+
+
+class TestDockerSecretOSError:
+    """C-3: _read_docker_secret catches OSError broadly, not just FileNotFoundError."""
+
+    def test_permission_error_logs_warning_returns_none(self, mock_store, tmp_path, monkeypatch, caplog):
+        """PermissionError on Docker secret logs warning, returns None, resolver continues."""
+        secret_path = tmp_path / "github_token"
+        secret_path.write_text("github_pat_test1234")
+        secret_path.chmod(0o000)
+        monkeypatch.setenv("GITHUB_TOKEN", "github_pat_from_env")
+
+        resolver = CredentialResolver(store=mock_store, docker_secret_path=str(secret_path))
+        try:
+            with caplog.at_level(logging.WARNING, logger="server.credential_resolver"):
+                result = resolver.resolve()
+        finally:
+            secret_path.chmod(0o644)
+
+        # Should fall through to env var, not crash
+        assert result is not None
+        assert result.source == CredentialSource.ENV_VAR
+        assert "could not be read" in caplog.text
+
+
+class TestStoreLoadOSError:
+    """C-3 (Finding 6): resolve() catches OSError from store.load()."""
+
+    def test_store_load_oserror_logs_warning_continues(self, mock_store, tmp_path, monkeypatch, caplog):
+        """OSError from store.load() is caught; resolver returns None gracefully."""
+        mock_store.load.side_effect = OSError("disk read error")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        resolver = CredentialResolver(
+            store=mock_store,
+            docker_secret_path=str(tmp_path / "nonexistent"),
+        )
+        with caplog.at_level(logging.WARNING, logger="server.credential_resolver"):
+            result = resolver.resolve()
+
+        assert result is None
+        assert "Failed to read stored credential" in caplog.text
+
+
+class TestResolvedCredentialFrozen:
+    """S-3: ResolvedCredential is frozen and rejects empty tokens."""
+
+    def test_empty_token_raises_value_error(self):
+        """ResolvedCredential with empty string token raises ValueError."""
+        with pytest.raises(ValueError, match="non-empty token"):
+            ResolvedCredential(token="", source=CredentialSource.ENV_VAR)
+
+    def test_frozen_prevents_mutation(self):
+        """ResolvedCredential attributes cannot be modified after creation."""
+        cred = ResolvedCredential(token="github_pat_test", source=CredentialSource.ENV_VAR)
+        with pytest.raises(AttributeError):
+            cred.token = "github_pat_other"
+
+    def test_valid_token_succeeds(self):
+        """ResolvedCredential with valid token creates normally."""
+        cred = ResolvedCredential(token="github_pat_test", source=CredentialSource.STORED)
+        assert cred.token == "github_pat_test"
+        assert cred.source == CredentialSource.STORED

--- a/tests/test_credential_resolver.py
+++ b/tests/test_credential_resolver.py
@@ -355,17 +355,26 @@ class TestDockerSecretOSError:
 
     def test_permission_error_logs_warning_returns_none(self, mock_store, tmp_path, monkeypatch, caplog):
         """PermissionError on Docker secret logs warning, returns None, resolver continues."""
+        import builtins
+
         secret_path = tmp_path / "github_token"
-        secret_path.write_text("github_pat_test1234")
-        secret_path.chmod(0o000)
         monkeypatch.setenv("GITHUB_TOKEN", "github_pat_from_env")
 
         resolver = CredentialResolver(store=mock_store, docker_secret_path=str(secret_path))
-        try:
-            with caplog.at_level(logging.WARNING, logger="server.credential_resolver"):
-                result = resolver.resolve()
-        finally:
-            secret_path.chmod(0o644)
+
+        # Patch open() to raise PermissionError only for the secret path.
+        # (chmod(0o000) is runner-dependent — fails under root / on Windows)
+        _real_open = builtins.open
+
+        def _open_permission_denied(path, *args, **kwargs):
+            if str(path) == str(secret_path):
+                raise PermissionError("Permission denied")
+            return _real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", _open_permission_denied)
+
+        with caplog.at_level(logging.WARNING, logger="server.credential_resolver"):
+            result = resolver.resolve()
 
         # Should fall through to env var, not crash
         assert result is not None

--- a/tests/test_credential_resolver.py
+++ b/tests/test_credential_resolver.py
@@ -22,6 +22,7 @@ from server.credential_resolver import CredentialResolver, CredentialSource, Res
 def mock_store():
     store = MagicMock()
     store.load.return_value = None
+    store.has_stored_credential.return_value = False
     return store
 
 
@@ -153,6 +154,7 @@ class TestGetSource:
     def test_returns_stored(self, mock_store, tmp_path, monkeypatch):
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         mock_store.load.return_value = "github_pat_test1234"
+        mock_store.has_stored_credential.return_value = True
         resolver = CredentialResolver(
             store=mock_store,
             docker_secret_path=str(tmp_path / "nonexistent"),
@@ -211,6 +213,7 @@ class TestSourcePriorityIntegration:
         """SC-004 combo 3 (US3-AS3): stored only (no Docker secret, no env var) → stored used."""
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         mock_store.load.return_value = "github_pat_from_stored"
+        mock_store.has_stored_credential.return_value = True
 
         resolver = CredentialResolver(
             store=mock_store,

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -1,0 +1,231 @@
+"""Tests for CredentialStore — T006 (RED).
+
+Covers: store(), load(), delete(), has_stored_credential(), get_metadata(),
+update_last_validated(), atomic writes, key loss handling.
+Per contract: specs/002-credential-setup/contracts/credential-store.md
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+from server.credential_store import CredentialMetadata, CredentialStore
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    """Provide a temp directory simulating /data/."""
+    return str(tmp_path)
+
+
+@pytest.fixture
+def store(data_dir):
+    return CredentialStore(data_dir=data_dir)
+
+
+class TestStore:
+    def test_store_creates_fernet_key(self, store, data_dir):
+        """First store() creates .fernet_key file."""
+        store.store("github_pat_test1234")
+        key_path = os.path.join(data_dir, ".fernet_key")
+        assert os.path.exists(key_path)
+
+    def test_store_creates_encrypted_file(self, store, data_dir):
+        """store() creates credentials.enc."""
+        store.store("github_pat_test1234")
+        enc_path = os.path.join(data_dir, "credentials.enc")
+        assert os.path.exists(enc_path)
+        # Encrypted file should NOT contain plaintext token
+        with open(enc_path, "rb") as f:
+            content = f.read()
+        assert b"github_pat_test1234" not in content
+
+    def test_store_creates_metadata(self, store, data_dir):
+        """store() creates credential_meta.json with timestamps."""
+        store.store("github_pat_test1234")
+        meta_path = os.path.join(data_dir, "credential_meta.json")
+        assert os.path.exists(meta_path)
+        with open(meta_path) as f:
+            meta = json.load(f)
+        assert "created_at" in meta
+        assert "last_validated_at" in meta
+
+    def test_store_reuses_existing_key(self, store, data_dir):
+        """Second store() reuses existing .fernet_key."""
+        store.store("github_pat_first")
+        key_path = os.path.join(data_dir, ".fernet_key")
+        with open(key_path, "rb") as f:
+            key1 = f.read()
+        store.store("github_pat_second")
+        with open(key_path, "rb") as f:
+            key2 = f.read()
+        assert key1 == key2
+
+    def test_store_key_permissions(self, store, data_dir):
+        """Fernet key file should have restrictive permissions (chmod 600)."""
+        store.store("github_pat_test1234")
+        key_path = os.path.join(data_dir, ".fernet_key")
+        mode = os.stat(key_path).st_mode & 0o777
+        assert mode == 0o600
+
+
+class TestLoad:
+    def test_load_decrypts_stored_token(self, store):
+        """load() returns the original plaintext token."""
+        store.store("github_pat_my_secret_token")
+        loaded = store.load()
+        assert loaded == "github_pat_my_secret_token"
+
+    def test_load_returns_none_on_missing_file(self, store):
+        """load() returns None when no credentials.enc exists."""
+        assert store.load() is None
+
+    def test_load_returns_none_on_missing_key(self, store, data_dir):
+        """FR-001: Key loss → load() returns None (AC-9)."""
+        store.store("github_pat_test1234")
+        # Delete the key file
+        os.remove(os.path.join(data_dir, ".fernet_key"))
+        assert store.load() is None
+
+    def test_load_returns_none_on_corrupted_file(self, store, data_dir):
+        """Decryption failure → load() returns None."""
+        store.store("github_pat_test1234")
+        enc_path = os.path.join(data_dir, "credentials.enc")
+        with open(enc_path, "wb") as f:
+            f.write(b"corrupted data")
+        assert store.load() is None
+
+
+class TestDelete:
+    def test_delete_removes_credential_files(self, store, data_dir):
+        """delete() removes credentials.enc and credential_meta.json."""
+        store.store("github_pat_test1234")
+        store.delete()
+        assert not os.path.exists(os.path.join(data_dir, "credentials.enc"))
+        assert not os.path.exists(os.path.join(data_dir, "credential_meta.json"))
+
+    def test_delete_keeps_fernet_key(self, store, data_dir):
+        """delete() does NOT remove .fernet_key."""
+        store.store("github_pat_test1234")
+        store.delete()
+        assert os.path.exists(os.path.join(data_dir, ".fernet_key"))
+
+    def test_delete_noop_when_no_credential(self, store):
+        """delete() does not raise when nothing to delete."""
+        store.delete()  # Should not raise
+
+
+class TestHasStoredCredential:
+    def test_returns_true_when_stored(self, store):
+        store.store("github_pat_test1234")
+        assert store.has_stored_credential() is True
+
+    def test_returns_false_when_empty(self, store):
+        assert store.has_stored_credential() is False
+
+    def test_returns_false_after_delete(self, store):
+        store.store("github_pat_test1234")
+        store.delete()
+        assert store.has_stored_credential() is False
+
+
+class TestGetMetadata:
+    def test_returns_metadata_after_store(self, store):
+        store.store("github_pat_test1234")
+        meta = store.get_metadata()
+        assert meta is not None
+        assert isinstance(meta, CredentialMetadata)
+        assert isinstance(meta.created_at, datetime)
+        assert isinstance(meta.last_validated_at, datetime)
+
+    def test_returns_none_when_no_metadata(self, store):
+        assert store.get_metadata() is None
+
+
+class TestUpdateLastValidated:
+    def test_updates_last_validated_at(self, store):
+        store.store("github_pat_test1234")
+        meta_before = store.get_metadata()
+        assert meta_before is not None
+
+        store.update_last_validated()
+        meta_after = store.get_metadata()
+        assert meta_after is not None
+        assert meta_after.last_validated_at >= meta_before.last_validated_at
+
+    def test_noop_when_no_metadata(self, store):
+        """update_last_validated with no metadata file is a no-op."""
+        store.update_last_validated()  # Should not raise
+        assert store.get_metadata() is None
+
+
+class TestLoadIOErrorPropagation:
+    """H-1: File I/O errors must propagate, not silently return None."""
+
+    def test_load_propagates_permission_error(self, store, data_dir):
+        """PermissionError on credentials.enc must raise, not return None."""
+        store.store("github_pat_test1234")
+        enc_path = os.path.join(data_dir, "credentials.enc")
+        os.chmod(enc_path, 0o000)
+        try:
+            with pytest.raises(PermissionError):
+                store.load()
+        finally:
+            os.chmod(enc_path, 0o644)
+
+    def test_load_propagates_key_permission_error(self, store, data_dir):
+        """PermissionError on .fernet_key must raise, not return None."""
+        store.store("github_pat_test1234")
+        key_path = os.path.join(data_dir, ".fernet_key")
+        os.chmod(key_path, 0o000)
+        try:
+            with pytest.raises(PermissionError):
+                store.load()
+        finally:
+            os.chmod(key_path, 0o600)
+
+
+class TestCorruptedMetadata:
+    """C-1: _read_meta_dict handles corrupted JSON gracefully."""
+
+    def test_read_meta_dict_with_corrupted_json(self, store, data_dir):
+        """_read_meta_dict returns {} when credential_meta.json contains invalid JSON."""
+        meta_path = os.path.join(data_dir, "credential_meta.json")
+        with open(meta_path, "w") as f:
+            f.write("{invalid json content!!!")
+        assert store._read_meta_dict() == {}
+
+    def test_store_succeeds_with_corrupted_metadata(self, store, data_dir):
+        """store() succeeds even when existing metadata is corrupted."""
+        # First store to create key and files
+        store.store("github_pat_first")
+        # Corrupt the metadata file
+        meta_path = os.path.join(data_dir, "credential_meta.json")
+        with open(meta_path, "w") as f:
+            f.write("not valid json")
+        # store() should still succeed — corrupted meta treated as empty
+        store.store("github_pat_second")
+        assert store.load() == "github_pat_second"
+        # Metadata should be valid again after re-store
+        meta = store.get_metadata()
+        assert meta is not None
+
+    def test_get_metadata_returns_none_with_malformed_dates(self, store, data_dir):
+        """get_metadata() returns None when date strings are malformed."""
+        meta_path = os.path.join(data_dir, "credential_meta.json")
+        with open(meta_path, "w") as f:
+            json.dump({"created_at": "not-a-date", "last_validated_at": "also-bad"}, f)
+        assert store.get_metadata() is None
+
+
+class TestAtomicWrites:
+    def test_store_uses_atomic_writes(self, store, data_dir):
+        """Verify store() uses os.replace() — encrypted file is valid after store."""
+        store.store("github_pat_first")
+        store.store("github_pat_second")
+        # Both stores should produce valid state
+        assert store.load() == "github_pat_second"

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -140,9 +140,18 @@ class TestGetMetadata:
         assert meta is not None
         assert isinstance(meta, CredentialMetadata)
         assert isinstance(meta.created_at, datetime)
-        assert isinstance(meta.last_validated_at, datetime)
+        # last_validated_at is None until update_last_validated() is called
+        assert meta.last_validated_at is None
 
     def test_returns_none_when_no_metadata(self, store):
+        assert store.get_metadata() is None
+
+    def test_returns_none_with_missing_keys(self, store, data_dir):
+        """get_metadata returns None when JSON has missing keys."""
+        store.store("github_pat_test1234")
+        meta_path = os.path.join(data_dir, "credential_meta.json")
+        with open(meta_path, "w") as f:
+            json.dump({"some_other_key": "value"}, f)
         assert store.get_metadata() is None
 
 
@@ -152,15 +161,25 @@ class TestUpdateLastValidated:
         meta_before = store.get_metadata()
         assert meta_before is not None
 
+        assert meta_before.last_validated_at is None
+
         store.update_last_validated()
         meta_after = store.get_metadata()
         assert meta_after is not None
-        assert meta_after.last_validated_at >= meta_before.last_validated_at
+        assert isinstance(meta_after.last_validated_at, datetime)
 
     def test_noop_when_no_metadata(self, store):
         """update_last_validated with no metadata file is a no-op."""
         store.update_last_validated()  # Should not raise
         assert store.get_metadata() is None
+
+    def test_noop_when_metadata_corrupted(self, store, data_dir):
+        """update_last_validated is a no-op when metadata is corrupted."""
+        store.store("github_pat_test1234")
+        meta_path = os.path.join(data_dir, "credential_meta.json")
+        with open(meta_path, "w") as f:
+            f.write("not valid json")
+        store.update_last_validated()  # Should not raise
 
 
 class TestLoadIOErrorPropagation:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -70,7 +70,9 @@ class TestFernetKeyLoss:
         )
         result = resolver.resolve()
         assert result is None
-        assert resolver.get_source() == CredentialSource.NONE
+        # get_source() is a lightweight check (file existence, not decryptability),
+        # so it reports STORED even though the key is lost and resolve() returns None.
+        assert resolver.get_source() == CredentialSource.STORED
 
     def test_key_loss_metadata_still_readable(self, tmp_path):
         """Key loss does not affect metadata reading (metadata is not encrypted)."""
@@ -272,7 +274,8 @@ class TestAtomicWriteEdgeCases:
         meta2 = store.get_metadata()
         assert meta2 is not None
         assert meta2.created_at == original_created
-        assert meta2.last_validated_at >= meta1.last_validated_at
+        # last_validated_at is None for both (never validated), just check consistency
+        assert meta2.last_validated_at == meta1.last_validated_at
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,0 +1,453 @@
+"""Edge case tests for credential management — T025.
+
+Covers:
+1. Fernet key loss with existing credential file (AC-9)
+2. Decryption failure (corrupted file)
+3. Copilot SDK unavailable during validation
+4. Concurrent store/load (atomic writes)
+5. Stored credential becomes invalid between restarts (EC-2)
+6. ResolvedCredential.__repr__ doesn't expose token (security audit T024)
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from server.copilot_client import (
+    CopilotAuthError,
+    CopilotReviewClient,
+    CopilotUnavailableError,
+)
+from server.credential_resolver import CredentialResolver, ResolvedCredential, CredentialSource
+from server.credential_store import CredentialStore
+from server.token_validator import TokenValidationError, TokenValidator
+
+
+# ---------------------------------------------------------------------------
+# 1. Fernet key loss with existing credential file (AC-9)
+#
+# Existing tests in test_credential_store.py cover:
+#   - test_load_returns_none_on_missing_key (basic key-loss)
+# Additional edge cases added here:
+# ---------------------------------------------------------------------------
+
+
+class TestFernetKeyLoss:
+    def test_key_loss_logs_warning_without_token_data(self, tmp_path, caplog):
+        """AC-9: Key loss logs a warning that does NOT contain any token data."""
+        store = CredentialStore(data_dir=str(tmp_path))
+        store.store("github_pat_secret_value_12345678")
+
+        # Delete the key
+        os.remove(tmp_path / ".fernet_key")
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            result = store.load()
+
+        assert result is None
+        # Warning was logged
+        assert any("Fernet key missing" in r.message for r in caplog.records)
+        # Token value does NOT appear in any log message
+        for record in caplog.records:
+            assert "github_pat_secret_value_12345678" not in record.message
+
+    def test_key_loss_with_resolver_falls_through(self, tmp_path, monkeypatch):
+        """AC-9 + resolver: Key loss means stored source unavailable, resolver returns None."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        store = CredentialStore(data_dir=str(tmp_path))
+        store.store("github_pat_stored_token_1234")
+
+        # Delete the key
+        os.remove(tmp_path / ".fernet_key")
+
+        resolver = CredentialResolver(
+            store=store,
+            docker_secret_path=str(tmp_path / "nonexistent_secret"),
+        )
+        result = resolver.resolve()
+        assert result is None
+        assert resolver.get_source() == CredentialSource.NONE
+
+    def test_key_loss_metadata_still_readable(self, tmp_path):
+        """Key loss does not affect metadata reading (metadata is not encrypted)."""
+        store = CredentialStore(data_dir=str(tmp_path))
+        store.store("github_pat_test1234")
+
+        # Delete the key
+        os.remove(tmp_path / ".fernet_key")
+
+        # Metadata is JSON, not encrypted — still readable
+        meta = store.get_metadata()
+        assert meta is not None
+        assert meta.created_at is not None
+
+    def test_key_loss_allows_fresh_store(self, tmp_path):
+        """After key loss, store() creates a new key and stores successfully."""
+        store = CredentialStore(data_dir=str(tmp_path))
+        store.store("github_pat_original_token")
+
+        # Delete the key
+        os.remove(tmp_path / ".fernet_key")
+
+        # Cannot load old credential
+        assert store.load() is None
+
+        # Store a new credential — should create a new key
+        store.store("github_pat_new_token_5678")
+        assert store.load() == "github_pat_new_token_5678"
+        assert os.path.exists(tmp_path / ".fernet_key")
+
+
+# ---------------------------------------------------------------------------
+# 2. Decryption failure (corrupted file)
+#
+# Existing tests in test_credential_store.py cover:
+#   - test_load_returns_none_on_corrupted_file (basic corruption)
+# Additional edge cases added here:
+# ---------------------------------------------------------------------------
+
+
+class TestDecryptionFailure:
+    def test_corrupted_file_logs_warning_without_token_data(self, tmp_path, caplog):
+        """Corrupted credential file logs a warning without exposing token data."""
+        store = CredentialStore(data_dir=str(tmp_path))
+        store.store("github_pat_secret_value_12345678")
+
+        # Corrupt the encrypted file
+        enc_path = tmp_path / "credentials.enc"
+        enc_path.write_bytes(b"totally corrupted garbage data!!!")
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            result = store.load()
+
+        assert result is None
+        # Warning was logged about decryption failure
+        assert any("Failed to decrypt" in r.message for r in caplog.records)
+        # Token value does NOT appear in any log message
+        for record in caplog.records:
+            assert "github_pat_secret_value_12345678" not in record.message
+
+    def test_empty_encrypted_file_returns_none(self, tmp_path):
+        """Empty credentials.enc file is handled gracefully."""
+        store = CredentialStore(data_dir=str(tmp_path))
+        store.store("github_pat_test1234")
+
+        # Truncate the encrypted file to zero bytes
+        enc_path = tmp_path / "credentials.enc"
+        enc_path.write_bytes(b"")
+
+        assert store.load() is None
+
+    def test_partial_fernet_token_returns_none(self, tmp_path):
+        """Partially valid Fernet ciphertext (truncated) returns None."""
+        store = CredentialStore(data_dir=str(tmp_path))
+        store.store("github_pat_test1234")
+
+        # Read the encrypted file and truncate it partway
+        enc_path = tmp_path / "credentials.enc"
+        full_data = enc_path.read_bytes()
+        enc_path.write_bytes(full_data[:len(full_data) // 2])
+
+        assert store.load() is None
+
+    def test_corruption_with_resolver_falls_through(self, tmp_path, monkeypatch):
+        """Corrupted credential file means stored source unavailable."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        store = CredentialStore(data_dir=str(tmp_path))
+        store.store("github_pat_stored_token_1234")
+
+        # Corrupt the file
+        enc_path = tmp_path / "credentials.enc"
+        enc_path.write_bytes(b"corrupted")
+
+        resolver = CredentialResolver(
+            store=store,
+            docker_secret_path=str(tmp_path / "nonexistent_secret"),
+        )
+        result = resolver.resolve()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Copilot SDK unavailable during validation
+#
+# Existing tests in test_token_validator.py cover:
+#   - test_sdk_error_on_import_error
+#   - test_sdk_error_on_unavailable
+# Additional edge case: full validate() orchestration with SDK unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestCopilotSdkUnavailable:
+    @pytest.mark.asyncio
+    async def test_full_validate_with_sdk_unavailable(self):
+        """Full validation pipeline: format passes, auth probe passes, SDK fails.
+
+        Verifies the "sdk" error type is produced with verbose container-level message.
+        """
+        mock_client = AsyncMock()
+        mock_client.start = AsyncMock(
+            side_effect=CopilotUnavailableError("CLI not found")
+        )
+        mock_client.stop = AsyncMock()
+
+        validator = TokenValidator(copilot_client_factory=lambda: mock_client)
+
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.return_value = 200  # Auth probe succeeds
+            with pytest.raises(TokenValidationError) as exc_info:
+                await validator.validate("github_pat_valid_format_token")
+
+        assert exc_info.value.error_type == "sdk"
+        assert "container configuration issue" in exc_info.value.message
+        assert "not a problem with your token" in exc_info.value.message
+        assert "docker compose build --no-cache" in exc_info.value.message
+        assert "docker compose logs" in exc_info.value.message
+        assert "docs.github.com/en/copilot" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_sdk_error_does_not_echo_token(self):
+        """SDK error message must NOT contain the submitted token value."""
+        test_token = "github_pat_my_secret_pat_value_1234"
+        mock_client = AsyncMock()
+        mock_client.start = AsyncMock(
+            side_effect=CopilotUnavailableError("CLI not found")
+        )
+        mock_client.stop = AsyncMock()
+
+        validator = TokenValidator(copilot_client_factory=lambda: mock_client)
+
+        with pytest.raises(TokenValidationError) as exc_info:
+            await validator.validate_copilot_access(
+                test_token, github_auth_confirmed=True
+            )
+
+        assert test_token not in exc_info.value.message
+
+
+# ---------------------------------------------------------------------------
+# 4. Concurrent store/load (atomic writes)
+#
+# Existing tests in test_credential_store.py cover:
+#   - test_store_uses_atomic_writes (two sequential stores produce valid state)
+# Additional edge cases for sequential store/load interleaving:
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWriteEdgeCases:
+    def test_sequential_store_load_always_returns_latest(self, tmp_path):
+        """Multiple sequential store+load cycles always return the latest value."""
+        store = CredentialStore(data_dir=str(tmp_path))
+
+        tokens = [f"github_pat_token_{i:04d}" for i in range(10)]
+        for token in tokens:
+            store.store(token)
+            loaded = store.load()
+            assert loaded == token, f"Expected {token}, got {loaded}"
+
+    def test_store_does_not_leave_temp_files(self, tmp_path):
+        """store() cleans up temporary files after atomic write."""
+        store = CredentialStore(data_dir=str(tmp_path))
+        store.store("github_pat_test1234")
+
+        # No .tmp files should remain
+        files = os.listdir(str(tmp_path))
+        tmp_files = [f for f in files if f.endswith(".tmp")]
+        assert tmp_files == [], f"Temp files left behind: {tmp_files}"
+
+    def test_overwrite_preserves_created_at(self, tmp_path):
+        """Storing a new token preserves original created_at timestamp."""
+        store = CredentialStore(data_dir=str(tmp_path))
+        store.store("github_pat_first_token")
+        meta1 = store.get_metadata()
+        assert meta1 is not None
+        original_created = meta1.created_at
+
+        store.store("github_pat_second_token")
+        meta2 = store.get_metadata()
+        assert meta2 is not None
+        assert meta2.created_at == original_created
+        assert meta2.last_validated_at >= meta1.last_validated_at
+
+
+# ---------------------------------------------------------------------------
+# 5. Stored credential becomes invalid between restarts (EC-2)
+#
+# When a stored credential was valid at store time but later becomes invalid
+# (e.g., revoked on GitHub), the system must detect this on first MCP tool use
+# and return "auth_failed" (not "no_credential" or "internal").
+# ---------------------------------------------------------------------------
+
+
+class TestStoredCredentialBecomesInvalid:
+    @pytest.mark.asyncio
+    async def test_auth_error_on_first_use_not_startup(self):
+        """EC-2: Invalid stored credential detected at tool invocation, not startup.
+
+        When CopilotReviewClient raises CopilotAuthError during start_review,
+        the MCP handler maps it to error="auth_failed", not "no_credential"
+        or "internal".
+        """
+        from server.mcp_server import start_review
+
+        with patch("server.mcp_server._engine") as mock_engine:
+            mock_engine.start_review = AsyncMock(
+                side_effect=CopilotAuthError(
+                    "Token authentication failed — the token appears to be "
+                    "expired or revoked."
+                )
+            )
+
+            response = await start_review(
+                diff="--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-old\n+new\n",
+                files={"f.py": "new"},
+            )
+
+        assert response["error"] == "auth_failed"
+        assert response["retryable"] is False
+        # Verify it's NOT mapped to the wrong error types
+        assert response["error"] != "no_credential"
+        assert response["error"] != "internal"
+
+    @pytest.mark.asyncio
+    async def test_auth_error_message_does_not_expose_token(self):
+        """EC-2 safety: Auth error messages must not contain plaintext tokens."""
+        from server.mcp_server import start_review
+
+        with patch("server.mcp_server._engine") as mock_engine:
+            mock_engine.start_review = AsyncMock(
+                side_effect=CopilotAuthError(
+                    "Token authentication failed — the token appears to be "
+                    "expired or revoked."
+                )
+            )
+
+            response = await start_review(
+                diff="--- a/f.py\n+++ b/f.py\n",
+                files={"f.py": "pass"},
+            )
+
+        # Error message must not contain any PAT-like strings
+        msg = response.get("message", "")
+        assert "github_pat_" not in msg
+
+    @pytest.mark.asyncio
+    async def test_discuss_auth_error_maps_correctly(self):
+        """EC-2 for discuss: Mid-session auth revocation maps to auth_failed."""
+        from server.mcp_server import discuss
+
+        with patch("server.mcp_server._engine") as mock_engine:
+            mock_engine.discuss = AsyncMock(
+                side_effect=CopilotAuthError(
+                    "Token authentication failed during discussion."
+                )
+            )
+
+            response = await discuss(
+                session_id="s-123",
+                message="Follow-up question",
+            )
+
+        assert response["error"] == "auth_failed"
+        assert response["retryable"] is False
+        assert response["error"] != "internal"
+
+
+# ---------------------------------------------------------------------------
+# 6. Security: ResolvedCredential.__repr__ doesn't expose token (T024 fix)
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedCredentialRepr:
+    def test_repr_does_not_contain_token(self):
+        """ResolvedCredential repr must mask the token value."""
+        token = "github_pat_my_super_secret_token_1234"
+        cred = ResolvedCredential(token=token, source=CredentialSource.STORED)
+
+        repr_str = repr(cred)
+        assert token not in repr_str
+        assert "***masked***" in repr_str
+        assert "STORED" in repr_str
+
+    def test_repr_for_all_sources(self):
+        """Repr is safe regardless of credential source."""
+        for source in CredentialSource:
+            if source == CredentialSource.NONE:
+                continue
+            cred = ResolvedCredential(
+                token="github_pat_secret_value", source=source
+            )
+            repr_str = repr(cred)
+            assert "github_pat_secret_value" not in repr_str
+
+    def test_token_still_accessible_via_attribute(self):
+        """Despite masked repr, the actual token is accessible via .token."""
+        token = "github_pat_actual_value_5678"
+        cred = ResolvedCredential(token=token, source=CredentialSource.ENV_VAR)
+        assert cred.token == token
+
+
+# ---------------------------------------------------------------------------
+# 7. Security: TokenValidator error messages don't echo submitted token
+# ---------------------------------------------------------------------------
+
+
+class TestTokenValidatorNoEcho:
+    def test_format_errors_do_not_echo_token(self):
+        """Format validation errors must not contain the submitted token."""
+        validator = TokenValidator(copilot_client_factory=lambda: AsyncMock())
+
+        bad_tokens = [
+            "ghp_classic_secret_value",
+            "gho_oauth_secret_value",
+            "ghs_app_server_secret",
+            "ghu_app_user_secret",
+            "totally_random_secret_string",
+        ]
+
+        for token in bad_tokens:
+            with pytest.raises(TokenValidationError) as exc_info:
+                validator.validate_format(token)
+            assert token not in exc_info.value.message, (
+                f"Token '{token}' was echoed in error message"
+            )
+
+    @pytest.mark.asyncio
+    async def test_auth_error_does_not_echo_token(self):
+        """Auth validation error (401) must not contain the submitted token."""
+        mock_client = AsyncMock()
+        validator = TokenValidator(copilot_client_factory=lambda: mock_client)
+
+        test_token = "github_pat_my_expired_secret_token"
+
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.return_value = 401
+            with pytest.raises(TokenValidationError) as exc_info:
+                await validator._probe_github_auth(test_token)
+
+        assert test_token not in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_permission_error_does_not_echo_token(self):
+        """Permission error must not contain the submitted token."""
+        mock_client = AsyncMock()
+        mock_client.start = AsyncMock(
+            side_effect=CopilotAuthError("403 Forbidden")
+        )
+        mock_client.stop = AsyncMock()
+
+        validator = TokenValidator(copilot_client_factory=lambda: mock_client)
+
+        test_token = "github_pat_my_permission_denied_token"
+
+        with pytest.raises(TokenValidationError) as exc_info:
+            await validator.validate_copilot_access(
+                test_token, github_auth_confirmed=True
+            )
+
+        assert test_token not in exc_info.value.message

--- a/tests/test_mcp_handlers.py
+++ b/tests/test_mcp_handlers.py
@@ -15,6 +15,7 @@ from server.copilot_client import (
     CopilotRateLimitError,
     CopilotTimeoutError,
     CopilotUnavailableError,
+    NoCredentialError,
 )
 from server.models import (
     DiscussResult,
@@ -165,6 +166,21 @@ class TestStartReviewHandler:
 
         response = await start_review(diff="d", files={"f.py": "pass"})
         assert response["error"] == "unavailable"
+        assert response["retryable"] is False
+
+    @pytest.mark.asyncio
+    async def test_no_credential_error_maps_correctly(self, _patch_engine):
+        """NoCredentialError must map to no_credential, not fall through to internal."""
+        from server.mcp_server import start_review
+
+        _patch_engine.start_review.side_effect = NoCredentialError(
+            "No credential configured. Set up a token at localhost:8080, "
+            "provide GITHUB_TOKEN env var, or mount a Docker secret at "
+            "/run/secrets/github_token."
+        )
+
+        response = await start_review(diff="d", files={"f.py": "pass"})
+        assert response["error"] == "no_credential"
         assert response["retryable"] is False
 
     @pytest.mark.asyncio

--- a/tests/test_mcp_server_config.py
+++ b/tests/test_mcp_server_config.py
@@ -95,8 +95,8 @@ def _patch_resolver(resolve_return):
     mock_cls = MagicMock()
     mock_cls.return_value.resolve.return_value = resolve_return
     return (
-        patch("server.credential_store.CredentialStore"),
-        patch("server.credential_resolver.CredentialResolver", mock_cls),
+        patch("server.mcp_server.CredentialStore"),
+        patch("server.mcp_server.CredentialResolver", mock_cls),
     )
 
 
@@ -186,6 +186,17 @@ class TestInitializeCopilotWithToken:
 
         assert isinstance(mock_copilot._startup_error, CopilotAuthError)
 
+    @pytest.mark.asyncio
+    async def test_not_connected_after_start_sets_unavailable(self, mock_copilot):
+        """Post-start is_connected=False sets CopilotUnavailableError."""
+        mock_copilot.is_connected = False
+        cred = ResolvedCredential(token="github_pat_abc123", source=CredentialSource.STORED)
+        p1, p2 = _patch_resolver(cred)
+        with p1, p2:
+            await _initialize_copilot()
+        assert isinstance(mock_copilot._startup_error, CopilotUnavailableError)
+        assert "not available" in str(mock_copilot._startup_error).lower()
+
 
 class TestInitializeCopilotRotation:
     """Fresh _initialize_copilot() after rotation picks up the new token."""
@@ -198,16 +209,16 @@ class TestInitializeCopilotRotation:
         # First call: old token
         resolver_cls = MagicMock()
         resolver_cls.return_value.resolve.return_value = old_cred
-        with patch("server.credential_store.CredentialStore"), \
-             patch("server.credential_resolver.CredentialResolver", resolver_cls):
+        with patch("server.mcp_server.CredentialStore"), \
+             patch("server.mcp_server.CredentialResolver", resolver_cls):
             await _initialize_copilot()
         mock_copilot.start.assert_awaited_with(github_token="github_pat_OLD")
 
         # Simulate rotation: second call picks up new token
         resolver_cls2 = MagicMock()
         resolver_cls2.return_value.resolve.return_value = new_cred
-        with patch("server.credential_store.CredentialStore"), \
-             patch("server.credential_resolver.CredentialResolver", resolver_cls2):
+        with patch("server.mcp_server.CredentialStore"), \
+             patch("server.mcp_server.CredentialResolver", resolver_cls2):
             await _initialize_copilot()
         mock_copilot.start.assert_awaited_with(github_token="github_pat_NEW")
 
@@ -218,8 +229,8 @@ class TestInitializeCopilotRotation:
         resolver_cls = MagicMock()
         resolver_cls.return_value.resolve.return_value = cred
 
-        with patch("server.credential_store.CredentialStore") as store_cls, \
-             patch("server.credential_resolver.CredentialResolver", resolver_cls):
+        with patch("server.mcp_server.CredentialStore") as store_cls, \
+             patch("server.mcp_server.CredentialResolver", resolver_cls):
             await _initialize_copilot()
             await _initialize_copilot()
 
@@ -277,8 +288,8 @@ class TestInitializeCopilotResolverFailure:
         """OSError from resolver.resolve() is wrapped in CopilotUnavailableError."""
         resolver_cls = MagicMock()
         resolver_cls.return_value.resolve.side_effect = OSError("disk read failed")
-        with patch("server.credential_store.CredentialStore"), \
-             patch("server.credential_resolver.CredentialResolver", resolver_cls):
+        with patch("server.mcp_server.CredentialStore"), \
+             patch("server.mcp_server.CredentialResolver", resolver_cls):
             await _initialize_copilot()
 
         assert isinstance(mock_copilot._startup_error, CopilotUnavailableError)
@@ -291,8 +302,8 @@ class TestInitializeCopilotResolverFailure:
         """OSError from resolver.resolve() is logged at ERROR level."""
         resolver_cls = MagicMock()
         resolver_cls.return_value.resolve.side_effect = OSError("disk read failed")
-        with patch("server.credential_store.CredentialStore"), \
-             patch("server.credential_resolver.CredentialResolver", resolver_cls), \
+        with patch("server.mcp_server.CredentialStore"), \
+             patch("server.mcp_server.CredentialResolver", resolver_cls), \
              caplog.at_level(logging.ERROR, logger="server.mcp_server"):
             await _initialize_copilot()
 
@@ -303,8 +314,8 @@ class TestInitializeCopilotResolverFailure:
         """When resolver crashes, start() is never called."""
         resolver_cls = MagicMock()
         resolver_cls.return_value.resolve.side_effect = OSError("disk read failed")
-        with patch("server.credential_store.CredentialStore"), \
-             patch("server.credential_resolver.CredentialResolver", resolver_cls):
+        with patch("server.mcp_server.CredentialStore"), \
+             patch("server.mcp_server.CredentialResolver", resolver_cls):
             await _initialize_copilot()
 
         mock_copilot.start.assert_not_called()

--- a/tests/test_mcp_server_config.py
+++ b/tests/test_mcp_server_config.py
@@ -242,7 +242,8 @@ class TestInitializeCopilotNonCopilotError:
 
         assert isinstance(mock_copilot._startup_error, CopilotUnavailableError)
         assert "RuntimeError" in str(mock_copilot._startup_error)
-        assert "segfault in SDK" in str(mock_copilot._startup_error)
+        # Raw exception text must NOT leak into user-facing error (security)
+        assert "segfault in SDK" not in str(mock_copilot._startup_error)
 
     @pytest.mark.asyncio
     async def test_runtime_error_logged(self, mock_copilot, caplog):
@@ -282,7 +283,8 @@ class TestInitializeCopilotResolverFailure:
 
         assert isinstance(mock_copilot._startup_error, CopilotUnavailableError)
         assert "OSError" in str(mock_copilot._startup_error)
-        assert "disk read failed" in str(mock_copilot._startup_error)
+        # Raw exception text must NOT leak into user-facing error (security)
+        assert "disk read failed" not in str(mock_copilot._startup_error)
 
     @pytest.mark.asyncio
     async def test_resolver_oserror_logged(self, mock_copilot, caplog):

--- a/tests/test_mcp_server_config.py
+++ b/tests/test_mcp_server_config.py
@@ -1,8 +1,19 @@
-"""Tests for MCP server configuration helpers — Issue #14."""
+"""Tests for MCP server configuration and startup — Issue #14, M-1."""
 
 from __future__ import annotations
 
-from server.mcp_server import _parse_timeout
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from server.copilot_client import (
+    CopilotAuthError,
+    CopilotUnavailableError,
+    NoCredentialError,
+)
+from server.credential_resolver import CredentialSource, ResolvedCredential
+from server.mcp_server import _initialize_copilot, _parse_timeout
 
 
 class TestParseTimeout:
@@ -59,3 +70,239 @@ class TestParseTimeout:
     def test_discuss_timeout_invalid_returns_default(self, monkeypatch):
         monkeypatch.setenv("DISCUSS_TIMEOUT", "nope")
         assert _parse_timeout("DISCUSS_TIMEOUT", 60.0) == 60.0
+
+
+# --- _initialize_copilot() tests (M-1: mcp_server.py:90-111 coverage) ---
+
+
+@pytest.fixture
+def mock_copilot():
+    """Replace module-level _copilot with a mock."""
+    copilot = AsyncMock()
+    copilot._startup_error = None
+    copilot.is_connected = True
+
+    def _set_startup_error(error):
+        copilot._startup_error = error
+
+    copilot.set_startup_error = _set_startup_error
+    with patch("server.mcp_server._copilot", copilot):
+        yield copilot
+
+
+def _patch_resolver(resolve_return):
+    """Patch CredentialStore + CredentialResolver so resolve() returns the given value."""
+    mock_cls = MagicMock()
+    mock_cls.return_value.resolve.return_value = resolve_return
+    return (
+        patch("server.credential_store.CredentialStore"),
+        patch("server.credential_resolver.CredentialResolver", mock_cls),
+    )
+
+
+class TestInitializeCopilotNoCredential:
+    """resolve() -> None sets NoCredentialError with all 3 remediation paths."""
+
+    @pytest.mark.asyncio
+    async def test_sets_no_credential_error(self, mock_copilot):
+        p1, p2 = _patch_resolver(None)
+        with p1, p2:
+            await _initialize_copilot()
+
+        assert isinstance(mock_copilot._startup_error, NoCredentialError)
+
+    @pytest.mark.asyncio
+    async def test_message_contains_web_ui_path(self, mock_copilot):
+        p1, p2 = _patch_resolver(None)
+        with p1, p2:
+            await _initialize_copilot()
+
+        assert "localhost:8080" in str(mock_copilot._startup_error)
+
+    @pytest.mark.asyncio
+    async def test_message_contains_env_var_path(self, mock_copilot):
+        p1, p2 = _patch_resolver(None)
+        with p1, p2:
+            await _initialize_copilot()
+
+        assert "GITHUB_TOKEN" in str(mock_copilot._startup_error)
+
+    @pytest.mark.asyncio
+    async def test_message_contains_docker_secret_path(self, mock_copilot):
+        p1, p2 = _patch_resolver(None)
+        with p1, p2:
+            await _initialize_copilot()
+
+        assert "/run/secrets/github_token" in str(mock_copilot._startup_error)
+
+    @pytest.mark.asyncio
+    async def test_copilot_start_not_called(self, mock_copilot):
+        p1, p2 = _patch_resolver(None)
+        with p1, p2:
+            await _initialize_copilot()
+
+        mock_copilot.start.assert_not_called()
+
+
+class TestInitializeCopilotWithToken:
+    """resolve() -> token passes that token into _copilot.start()."""
+
+    @pytest.mark.asyncio
+    async def test_token_passed_to_start(self, mock_copilot):
+        cred = ResolvedCredential(token="github_pat_abc123", source=CredentialSource.STORED)
+        p1, p2 = _patch_resolver(cred)
+        with p1, p2:
+            await _initialize_copilot()
+
+        mock_copilot.start.assert_awaited_once_with(github_token="github_pat_abc123")
+
+    @pytest.mark.asyncio
+    async def test_select_model_not_called_redundantly(self, mock_copilot):
+        """I-6: select_model() is handled internally by start(), not called again."""
+        mock_copilot.is_connected = True
+        cred = ResolvedCredential(token="github_pat_abc123", source=CredentialSource.STORED)
+        p1, p2 = _patch_resolver(cred)
+        with p1, p2:
+            await _initialize_copilot()
+
+        mock_copilot.select_model.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_startup_error_on_success(self, mock_copilot):
+        cred = ResolvedCredential(token="github_pat_abc123", source=CredentialSource.STORED)
+        p1, p2 = _patch_resolver(cred)
+        with p1, p2:
+            await _initialize_copilot()
+
+        assert mock_copilot._startup_error is None
+
+    @pytest.mark.asyncio
+    async def test_copilot_error_stored_on_start_failure(self, mock_copilot):
+        mock_copilot.start.side_effect = CopilotAuthError("bad token")
+        cred = ResolvedCredential(token="github_pat_bad", source=CredentialSource.ENV_VAR)
+        p1, p2 = _patch_resolver(cred)
+        with p1, p2:
+            await _initialize_copilot()
+
+        assert isinstance(mock_copilot._startup_error, CopilotAuthError)
+
+
+class TestInitializeCopilotRotation:
+    """Fresh _initialize_copilot() after rotation picks up the new token."""
+
+    @pytest.mark.asyncio
+    async def test_second_init_uses_rotated_token(self, mock_copilot):
+        old_cred = ResolvedCredential(token="github_pat_OLD", source=CredentialSource.STORED)
+        new_cred = ResolvedCredential(token="github_pat_NEW", source=CredentialSource.STORED)
+
+        # First call: old token
+        resolver_cls = MagicMock()
+        resolver_cls.return_value.resolve.return_value = old_cred
+        with patch("server.credential_store.CredentialStore"), \
+             patch("server.credential_resolver.CredentialResolver", resolver_cls):
+            await _initialize_copilot()
+        mock_copilot.start.assert_awaited_with(github_token="github_pat_OLD")
+
+        # Simulate rotation: second call picks up new token
+        resolver_cls2 = MagicMock()
+        resolver_cls2.return_value.resolve.return_value = new_cred
+        with patch("server.credential_store.CredentialStore"), \
+             patch("server.credential_resolver.CredentialResolver", resolver_cls2):
+            await _initialize_copilot()
+        mock_copilot.start.assert_awaited_with(github_token="github_pat_NEW")
+
+    @pytest.mark.asyncio
+    async def test_rotation_creates_fresh_resolver(self, mock_copilot):
+        """Each _initialize_copilot() call creates a new CredentialResolver."""
+        cred = ResolvedCredential(token="github_pat_X", source=CredentialSource.STORED)
+        resolver_cls = MagicMock()
+        resolver_cls.return_value.resolve.return_value = cred
+
+        with patch("server.credential_store.CredentialStore") as store_cls, \
+             patch("server.credential_resolver.CredentialResolver", resolver_cls):
+            await _initialize_copilot()
+            await _initialize_copilot()
+
+        # Two calls = two fresh CredentialStore + CredentialResolver instances
+        assert store_cls.call_count == 2
+        assert resolver_cls.call_count == 2
+
+
+class TestInitializeCopilotNonCopilotError:
+    """C-2: Non-CopilotError exceptions are logged and wrapped."""
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_stored_as_unavailable(self, mock_copilot):
+        """RuntimeError during start() is wrapped in CopilotUnavailableError."""
+        mock_copilot.start.side_effect = RuntimeError("segfault in SDK")
+        cred = ResolvedCredential(token="github_pat_abc123", source=CredentialSource.STORED)
+        p1, p2 = _patch_resolver(cred)
+        with p1, p2:
+            await _initialize_copilot()
+
+        assert isinstance(mock_copilot._startup_error, CopilotUnavailableError)
+        assert "RuntimeError" in str(mock_copilot._startup_error)
+        assert "segfault in SDK" in str(mock_copilot._startup_error)
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_logged(self, mock_copilot, caplog):
+        """RuntimeError during start() is logged at ERROR level."""
+        mock_copilot.start.side_effect = RuntimeError("segfault in SDK")
+        cred = ResolvedCredential(token="github_pat_abc123", source=CredentialSource.STORED)
+        p1, p2 = _patch_resolver(cred)
+        with p1, p2, caplog.at_level(logging.ERROR, logger="server.mcp_server"):
+            await _initialize_copilot()
+
+        assert any("Unexpected error during Copilot initialization" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_copilot_error_still_stored_directly(self, mock_copilot):
+        """CopilotAuthError is still stored as-is (not wrapped)."""
+        mock_copilot.start.side_effect = CopilotAuthError("bad token")
+        cred = ResolvedCredential(token="github_pat_bad", source=CredentialSource.ENV_VAR)
+        p1, p2 = _patch_resolver(cred)
+        with p1, p2:
+            await _initialize_copilot()
+
+        assert isinstance(mock_copilot._startup_error, CopilotAuthError)
+        assert "bad token" in str(mock_copilot._startup_error)
+
+
+class TestInitializeCopilotResolverFailure:
+    """C-2/Finding 14: resolver.resolve() OSError is caught separately."""
+
+    @pytest.mark.asyncio
+    async def test_resolver_oserror_stored_as_unavailable(self, mock_copilot):
+        """OSError from resolver.resolve() is wrapped in CopilotUnavailableError."""
+        resolver_cls = MagicMock()
+        resolver_cls.return_value.resolve.side_effect = OSError("disk read failed")
+        with patch("server.credential_store.CredentialStore"), \
+             patch("server.credential_resolver.CredentialResolver", resolver_cls):
+            await _initialize_copilot()
+
+        assert isinstance(mock_copilot._startup_error, CopilotUnavailableError)
+        assert "OSError" in str(mock_copilot._startup_error)
+        assert "disk read failed" in str(mock_copilot._startup_error)
+
+    @pytest.mark.asyncio
+    async def test_resolver_oserror_logged(self, mock_copilot, caplog):
+        """OSError from resolver.resolve() is logged at ERROR level."""
+        resolver_cls = MagicMock()
+        resolver_cls.return_value.resolve.side_effect = OSError("disk read failed")
+        with patch("server.credential_store.CredentialStore"), \
+             patch("server.credential_resolver.CredentialResolver", resolver_cls), \
+             caplog.at_level(logging.ERROR, logger="server.mcp_server"):
+            await _initialize_copilot()
+
+        assert any("Credential resolver failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_resolver_oserror_does_not_call_start(self, mock_copilot):
+        """When resolver crashes, start() is never called."""
+        resolver_cls = MagicMock()
+        resolver_cls.return_value.resolve.side_effect = OSError("disk read failed")
+        with patch("server.credential_store.CredentialStore"), \
+             patch("server.credential_resolver.CredentialResolver", resolver_cls):
+            await _initialize_copilot()
+
+        mock_copilot.start.assert_not_called()

--- a/tests/test_token_validator.py
+++ b/tests/test_token_validator.py
@@ -288,4 +288,4 @@ class TestValidateCopilotAccessUnexpectedError:
         with pytest.raises(TokenValidationError) as exc_info:
             await validator.validate_copilot_access("github_pat_test", github_auth_confirmed=None)
         assert exc_info.value.error_type == "sdk"
-        assert "Check container logs" in exc_info.value.message
+        assert "Try again or contact your administrator" in exc_info.value.message

--- a/tests/test_token_validator.py
+++ b/tests/test_token_validator.py
@@ -248,21 +248,21 @@ class TestProbeGithubAuthNarrowCatch:
 
 class TestValidateCopilotAccessUnexpectedError:
     @pytest.mark.asyncio
-    async def test_unexpected_runtime_error_raises_unknown(self, validator, mock_copilot):
-        """Unexpected RuntimeError → TokenValidationError with error_type='unknown'."""
+    async def test_unexpected_runtime_error_raises_sdk(self, validator, mock_copilot):
+        """Unexpected RuntimeError → TokenValidationError with error_type='sdk'."""
         mock_copilot.start.side_effect = RuntimeError("something broke")
 
         with pytest.raises(TokenValidationError) as exc_info:
             await validator.validate_copilot_access("github_pat_test", github_auth_confirmed=True)
-        assert exc_info.value.error_type == "unknown"
+        assert exc_info.value.error_type == "sdk"
         assert "unexpected error" in exc_info.value.message.lower()
 
     @pytest.mark.asyncio
-    async def test_unexpected_os_error_raises_unknown(self, validator, mock_copilot):
-        """Unexpected OSError → TokenValidationError with error_type='unknown'."""
+    async def test_unexpected_os_error_raises_sdk(self, validator, mock_copilot):
+        """Unexpected OSError → TokenValidationError with error_type='sdk'."""
         mock_copilot.start.side_effect = OSError("disk failure")
 
         with pytest.raises(TokenValidationError) as exc_info:
             await validator.validate_copilot_access("github_pat_test", github_auth_confirmed=None)
-        assert exc_info.value.error_type == "unknown"
+        assert exc_info.value.error_type == "sdk"
         assert "Check container logs" in exc_info.value.message

--- a/tests/test_token_validator.py
+++ b/tests/test_token_validator.py
@@ -1,0 +1,268 @@
+"""Tests for TokenValidator — T010 (RED).
+
+Covers: validate_format(), _probe_github_auth(), validate_copilot_access(),
+validate() orchestration. All 4 error types must assert message content and
+remediation URLs per contracts/token-validator.md (AC-3).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from server.token_validator import TokenValidationError, TokenValidator
+
+
+@pytest.fixture
+def mock_copilot():
+    client = AsyncMock()
+    client.start = AsyncMock()
+    client.stop = AsyncMock()
+    client._available_models = [{"id": "gpt-4o", "name": "gpt-4o"}]
+    return client
+
+
+@pytest.fixture
+def validator(mock_copilot):
+    return TokenValidator(copilot_client_factory=lambda: mock_copilot)
+
+
+class TestValidateFormat:
+    def test_accepts_fine_grained_pat(self, validator):
+        """github_pat_ prefix accepted."""
+        validator.validate_format("github_pat_1234567890abcdef")
+
+    def test_rejects_empty(self, validator):
+        """Empty string → format error with URL."""
+        with pytest.raises(TokenValidationError) as exc_info:
+            validator.validate_format("")
+        assert exc_info.value.error_type == "format"
+        assert "github.com/settings/tokens?type=beta" in exc_info.value.message
+
+    def test_rejects_whitespace_only(self, validator):
+        """Whitespace-only → format error with URL."""
+        with pytest.raises(TokenValidationError) as exc_info:
+            validator.validate_format("   ")
+        assert exc_info.value.error_type == "format"
+        assert "github.com/settings/tokens?type=beta" in exc_info.value.message
+
+    def test_rejects_classic_pat(self, validator):
+        """ghp_ prefix → format error identifying classic PAT with URL."""
+        with pytest.raises(TokenValidationError) as exc_info:
+            validator.validate_format("ghp_1234567890abcdef")
+        assert exc_info.value.error_type == "format"
+        assert "Classic PATs" in exc_info.value.message
+        assert "ghp_" in exc_info.value.message
+        assert "github.com/settings/tokens?type=beta" in exc_info.value.message
+
+    def test_rejects_oauth_token(self, validator):
+        """gho_ prefix → format error with URL."""
+        with pytest.raises(TokenValidationError) as exc_info:
+            validator.validate_format("gho_1234567890abcdef")
+        assert exc_info.value.error_type == "format"
+        assert "OAuth" in exc_info.value.message
+        assert "github.com/settings/tokens?type=beta" in exc_info.value.message
+
+    def test_rejects_ghs_token(self, validator):
+        """ghs_ prefix → format error with URL."""
+        with pytest.raises(TokenValidationError) as exc_info:
+            validator.validate_format("ghs_1234567890abcdef")
+        assert exc_info.value.error_type == "format"
+        assert "GitHub App" in exc_info.value.message
+        assert "github.com/settings/tokens?type=beta" in exc_info.value.message
+
+    def test_rejects_ghu_token(self, validator):
+        """ghu_ prefix → format error with URL."""
+        with pytest.raises(TokenValidationError) as exc_info:
+            validator.validate_format("ghu_1234567890abcdef")
+        assert exc_info.value.error_type == "format"
+        assert "GitHub App" in exc_info.value.message
+        assert "github.com/settings/tokens?type=beta" in exc_info.value.message
+
+    def test_rejects_unrecognized_format(self, validator):
+        """Unknown format → format error with URL."""
+        with pytest.raises(TokenValidationError) as exc_info:
+            validator.validate_format("some_random_token")
+        assert exc_info.value.error_type == "format"
+        assert "github_pat_" in exc_info.value.message
+        assert "github.com/settings/tokens?type=beta" in exc_info.value.message
+
+
+class TestProbeGithubAuth:
+    @pytest.mark.asyncio
+    async def test_returns_true_on_2xx(self, validator):
+        """GET /user 200 → True (auth confirmed)."""
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.return_value = 200
+            result = await validator._probe_github_auth("github_pat_valid")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_raises_auth_on_401(self, validator):
+        """GET /user 401 → auth error with verbose message and URL."""
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.return_value = 401
+            with pytest.raises(TokenValidationError) as exc_info:
+                await validator._probe_github_auth("github_pat_expired")
+        assert exc_info.value.error_type == "auth"
+        assert "expired or revoked" in exc_info.value.message
+        assert "github.com/settings/tokens" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_403(self, validator):
+        """GET /user 403 → None (inconclusive)."""
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.return_value = 403
+            result = await validator._probe_github_auth("github_pat_test")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_500(self, validator):
+        """GET /user 500 → None (inconclusive)."""
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.return_value = 500
+            result = await validator._probe_github_auth("github_pat_test")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_network_error(self, validator):
+        """Network error → None (inconclusive)."""
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.side_effect = OSError("connection refused")
+            result = await validator._probe_github_auth("github_pat_test")
+        assert result is None
+
+
+class TestValidateCopilotAccess:
+    @pytest.mark.asyncio
+    async def test_success(self, validator, mock_copilot):
+        """list_models() succeeds → no error raised."""
+        await validator.validate_copilot_access("github_pat_valid", github_auth_confirmed=True)
+        mock_copilot.start.assert_called_once()
+        mock_copilot.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_permission_error_when_auth_confirmed(self, validator, mock_copilot):
+        """Confirmed auth + Copilot failure → permission error with verbose message and URL."""
+        from server.copilot_client import CopilotAuthError
+        mock_copilot.start.side_effect = CopilotAuthError("403 Forbidden")
+
+        with pytest.raises(TokenValidationError) as exc_info:
+            await validator.validate_copilot_access("github_pat_test", github_auth_confirmed=True)
+        assert exc_info.value.error_type == "permission"
+        assert "authenticates to GitHub but cannot access Copilot" in exc_info.value.message
+        assert "github.com/settings/tokens" in exc_info.value.message
+        assert "github.com/settings/copilot" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_auth_error_when_inconclusive(self, validator, mock_copilot):
+        """Inconclusive probe + Copilot failure → auth error (combined) with verbose message and URL."""
+        from server.copilot_client import CopilotAuthError
+        mock_copilot.start.side_effect = CopilotAuthError("403 Forbidden")
+
+        with pytest.raises(TokenValidationError) as exc_info:
+            await validator.validate_copilot_access("github_pat_test", github_auth_confirmed=None)
+        assert exc_info.value.error_type == "auth"
+        assert "couldn't determine the exact cause" in exc_info.value.message
+        assert "github.com/settings/tokens" in exc_info.value.message
+        assert "github.com/settings/copilot" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_sdk_error_on_import_error(self, validator, mock_copilot):
+        """ImportError → sdk error with verbose message and URL."""
+        mock_copilot.start.side_effect = ImportError("No module named 'copilot'")
+
+        with pytest.raises(TokenValidationError) as exc_info:
+            await validator.validate_copilot_access("github_pat_test", github_auth_confirmed=True)
+        assert exc_info.value.error_type == "sdk"
+        assert "container configuration issue" in exc_info.value.message
+        assert "docker compose build --no-cache" in exc_info.value.message
+        assert "docs.github.com/en/copilot" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_sdk_error_on_unavailable(self, validator, mock_copilot):
+        """CopilotUnavailableError → sdk error with verbose message and URL."""
+        from server.copilot_client import CopilotUnavailableError
+        mock_copilot.start.side_effect = CopilotUnavailableError("CLI not found")
+
+        with pytest.raises(TokenValidationError) as exc_info:
+            await validator.validate_copilot_access("github_pat_test", github_auth_confirmed=True)
+        assert exc_info.value.error_type == "sdk"
+        assert "container configuration issue" in exc_info.value.message
+        assert "docs.github.com/en/copilot" in exc_info.value.message
+
+
+class TestValidateOrchestration:
+    @pytest.mark.asyncio
+    async def test_format_error_short_circuits(self, validator):
+        """Format error stops validation before any network call."""
+        with pytest.raises(TokenValidationError) as exc_info:
+            await validator.validate("ghp_classic_token")
+        assert exc_info.value.error_type == "format"
+
+    @pytest.mark.asyncio
+    async def test_auth_error_on_401_short_circuits(self, validator, mock_copilot):
+        """401 from probe short-circuits before Copilot check."""
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.return_value = 401
+            with pytest.raises(TokenValidationError) as exc_info:
+                await validator.validate("github_pat_expired")
+        assert exc_info.value.error_type == "auth"
+        mock_copilot.start.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_full_success(self, validator, mock_copilot):
+        """Valid token passes all three steps."""
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.return_value = 200
+            await validator.validate("github_pat_valid_token")
+        mock_copilot.start.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_inconclusive_probe_still_checks_copilot(self, validator, mock_copilot):
+        """Inconclusive probe (non-401, non-2xx) → Copilot check still runs."""
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.return_value = 403
+            await validator.validate("github_pat_valid_token")
+        mock_copilot.start.assert_called_once()
+
+
+class TestProbeGithubAuthNarrowCatch:
+    @pytest.mark.asyncio
+    async def test_non_network_error_propagates(self, validator):
+        """Non-network errors (e.g. TypeError) must NOT be caught — they propagate."""
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.side_effect = TypeError("unexpected argument")
+            with pytest.raises(TypeError, match="unexpected argument"):
+                await validator._probe_github_auth("github_pat_test")
+
+    @pytest.mark.asyncio
+    async def test_attribute_error_propagates(self, validator):
+        """AttributeError must NOT be caught — it indicates a bug."""
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.side_effect = AttributeError("bad attribute")
+            with pytest.raises(AttributeError, match="bad attribute"):
+                await validator._probe_github_auth("github_pat_test")
+
+
+class TestValidateCopilotAccessUnexpectedError:
+    @pytest.mark.asyncio
+    async def test_unexpected_runtime_error_raises_unknown(self, validator, mock_copilot):
+        """Unexpected RuntimeError → TokenValidationError with error_type='unknown'."""
+        mock_copilot.start.side_effect = RuntimeError("something broke")
+
+        with pytest.raises(TokenValidationError) as exc_info:
+            await validator.validate_copilot_access("github_pat_test", github_auth_confirmed=True)
+        assert exc_info.value.error_type == "unknown"
+        assert "unexpected error" in exc_info.value.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_unexpected_os_error_raises_unknown(self, validator, mock_copilot):
+        """Unexpected OSError → TokenValidationError with error_type='unknown'."""
+        mock_copilot.start.side_effect = OSError("disk failure")
+
+        with pytest.raises(TokenValidationError) as exc_info:
+            await validator.validate_copilot_access("github_pat_test", github_auth_confirmed=None)
+        assert exc_info.value.error_type == "unknown"
+        assert "Check container logs" in exc_info.value.message

--- a/tests/test_token_validator.py
+++ b/tests/test_token_validator.py
@@ -19,6 +19,7 @@ def mock_copilot():
     client = AsyncMock()
     client.start = AsyncMock()
     client.stop = AsyncMock()
+    client.is_connected = True
     client._available_models = [{"id": "gpt-4o", "name": "gpt-4o"}]
     return client
 
@@ -87,6 +88,12 @@ class TestValidateFormat:
         assert exc_info.value.error_type == "format"
         assert "github_pat_" in exc_info.value.message
         assert "github.com/settings/tokens?type=beta" in exc_info.value.message
+
+    def test_rejects_none(self, validator):
+        """validate_format rejects None input."""
+        with pytest.raises(TokenValidationError) as exc_info:
+            validator.validate_format(None)
+        assert exc_info.value.error_type == "format"
 
 
 class TestProbeGithubAuth:
@@ -192,6 +199,14 @@ class TestValidateCopilotAccess:
         assert "container configuration issue" in exc_info.value.message
         assert "docs.github.com/en/copilot" in exc_info.value.message
 
+    @pytest.mark.asyncio
+    async def test_sdk_error_when_not_connected_after_start(self, validator, mock_copilot):
+        """validate_copilot_access raises sdk error when client not connected after start."""
+        mock_copilot.is_connected = False
+        with pytest.raises(TokenValidationError) as exc_info:
+            await validator.validate_copilot_access("github_pat_test12345678", github_auth_confirmed=True)
+        assert exc_info.value.error_type == "sdk"
+
 
 class TestValidateOrchestration:
     @pytest.mark.asyncio
@@ -226,6 +241,14 @@ class TestValidateOrchestration:
             mock_get.return_value = 403
             await validator.validate("github_pat_valid_token")
         mock_copilot.start.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_whitespace_stripped_before_format_check(self, validator, mock_copilot):
+        """validate() strips whitespace before checking format."""
+        with patch("server.token_validator._http_get_status") as mock_get:
+            mock_get.return_value = 200
+            # Token with whitespace should pass if the stripped version is valid
+            await validator.validate("  github_pat_test12345678  \n")
 
 
 class TestProbeGithubAuthNarrowCatch:

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -1,0 +1,524 @@
+"""Tests for web routes — T011, T019 (RED).
+
+Covers: GET / redirect to /setup when no credential (AC-1), GET / renders
+status page, GET /setup renders wizard, GET /setup redirects when credential
+exists, POST /setup validates + stores + redirects (AC-2), POST /setup with
+invalid token re-renders with error (AC-3), mask_token() helper,
+GET /settings shows masked token + source + form (US2-AS1), GET /settings
+disables form for external sources (US2-AS4), GET /settings with no credential,
+POST /settings/rotate with valid token replaces old + redirects (AC-5),
+POST /settings/rotate with invalid token preserves old + shows error (US2-AS3),
+POST /settings/rotate rejected when source is not stored,
+POST /setup OSError handling, POST /settings/rotate OSError handling,
+logging assertions.
+Per contract: specs/002-credential-setup/contracts/web-routes.md
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server.credential_resolver import CredentialSource, ResolvedCredential
+from server.token_validator import TokenValidationError
+
+
+def _create_test_app(resolver_result=None, resolver_source=CredentialSource.NONE):
+    """Create a FastAPI test app with mocked dependencies."""
+    from server.web_routes import create_router, mask_token
+    from server.main import app as real_app
+    from fastapi import FastAPI
+    from fastapi.staticfiles import StaticFiles
+    from fastapi.templating import Jinja2Templates
+    import os
+
+    app = FastAPI()
+
+    templates_dir = os.path.join(os.path.dirname(__file__), "..", "server", "templates")
+    static_dir = os.path.join(os.path.dirname(__file__), "..", "server", "static")
+
+    templates = Jinja2Templates(directory=templates_dir)
+    app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+    mock_store = MagicMock()
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.return_value = resolver_result
+    mock_resolver.get_source.return_value = resolver_source
+    mock_validator = AsyncMock()
+
+    router = create_router(
+        templates=templates,
+        store=mock_store,
+        resolver=mock_resolver,
+        validator=mock_validator,
+    )
+    app.include_router(router)
+
+    return app, mock_store, mock_resolver, mock_validator
+
+
+class TestGetRoot:
+    def test_redirects_to_setup_when_no_credential(self):
+        """AC-1: No credential → redirect to /setup."""
+        app, _, _, _ = _create_test_app(resolver_result=None)
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/")
+        assert response.status_code in (302, 307)
+        assert "/setup" in response.headers["location"]
+
+    def test_renders_status_when_credential_exists(self):
+        """Credential exists → render status page with source + masked token."""
+        resolved = ResolvedCredential(token="github_pat_abcdefghXXXX", source=CredentialSource.STORED)
+        app, _, _, _ = _create_test_app(resolver_result=resolved, resolver_source=CredentialSource.STORED)
+        client = TestClient(app)
+        response = client.get("/")
+        assert response.status_code == 200
+        assert "XXXX" in response.text  # Masked token suffix visible
+        assert "github_pat_abcdefghXXXX" not in response.text  # Full token NOT visible
+
+    def test_flash_message_from_query_param(self):
+        """?msg=saved → flash message displayed."""
+        resolved = ResolvedCredential(token="github_pat_abcdefghXXXX", source=CredentialSource.STORED)
+        app, _, _, _ = _create_test_app(resolver_result=resolved, resolver_source=CredentialSource.STORED)
+        client = TestClient(app)
+        response = client.get("/?msg=saved")
+        assert response.status_code == 200
+        assert "Token saved successfully" in response.text
+
+
+class TestGetSetup:
+    def test_renders_wizard_when_no_credential(self):
+        """AC-1: No credential → setup wizard displayed."""
+        app, _, _, _ = _create_test_app(resolver_result=None)
+        client = TestClient(app)
+        response = client.get("/setup")
+        assert response.status_code == 200
+        assert "github.com/settings/tokens" in response.text
+
+    def test_redirects_when_credential_exists(self):
+        """Credential already configured → redirect to /."""
+        resolved = ResolvedCredential(token="github_pat_test1234", source=CredentialSource.STORED)
+        app, _, _, _ = _create_test_app(resolver_result=resolved)
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/setup")
+        assert response.status_code in (302, 307)
+        assert response.headers["location"] == "/"
+
+
+class TestPostSetup:
+    def test_valid_token_stores_and_redirects(self):
+        """AC-2: Valid token → validate, store, redirect to /?msg=saved."""
+        app, mock_store, _, mock_validator = _create_test_app(resolver_result=None)
+        mock_validator.validate = AsyncMock()  # No exception = success
+
+        client = TestClient(app, follow_redirects=False)
+        response = client.post("/setup", data={"token": "github_pat_valid_token"})
+        assert response.status_code in (302, 303)
+        assert "/?msg=saved" in response.headers["location"]
+        mock_store.store.assert_called_once_with("github_pat_valid_token")
+
+    def test_invalid_token_re_renders_with_error(self):
+        """AC-3: Invalid token → re-render setup with error message."""
+        app, mock_store, _, mock_validator = _create_test_app(resolver_result=None)
+        mock_validator.validate = AsyncMock(
+            side_effect=TokenValidationError("Classic PATs (ghp_) are not supported.", "format")
+        )
+
+        client = TestClient(app)
+        response = client.post("/setup", data={"token": "ghp_bad_token"})
+        assert response.status_code == 200
+        assert "Classic PATs" in response.text
+        mock_store.store.assert_not_called()
+
+
+class TestMaskToken:
+    def test_masks_standard_token(self):
+        from server.web_routes import mask_token
+        result = mask_token("github_pat_abcdefghijklmnop1234")
+        assert result.startswith("github_pat_")
+        assert result.endswith("1234")
+        assert "..." in result
+        # Should NOT contain full token
+        assert result != "github_pat_abcdefghijklmnop1234"
+
+    def test_masks_classic_pat(self):
+        """M-1: Classic PAT prefix derived from token, not hardcoded."""
+        from server.web_routes import mask_token
+        result = mask_token("ghp_abcdefghijklmnopqrstuvwxyz1234")
+        assert result.startswith("ghp_")
+        assert result.endswith("1234")
+        assert "..." in result
+        assert not result.startswith("github_pat_")
+
+    def test_masks_oauth_token(self):
+        """M-1: OAuth token prefix derived from token."""
+        from server.web_routes import mask_token
+        result = mask_token("gho_abcdefghijklmnopqrstuvwx5678")
+        assert result.startswith("gho_")
+        assert result.endswith("5678")
+
+    def test_masks_unknown_prefix(self):
+        """M-1: Unknown prefix shows first 4 chars."""
+        from server.web_routes import mask_token
+        result = mask_token("xyzw_abcdefghijklmnopqrst9999")
+        assert result.startswith("xyzw")
+        assert result.endswith("9999")
+        assert "..." in result
+
+    def test_masks_short_token(self):
+        from server.web_routes import mask_token
+        result = mask_token("github_pat_ab")
+        # Even short tokens should be masked
+        assert "..." in result
+
+    def test_empty_input(self):
+        from server.web_routes import mask_token
+        assert mask_token("") == ""
+
+    def test_none_input(self):
+        from server.web_routes import mask_token
+        assert mask_token(None) == ""
+
+
+class TestGetSettings:
+    """T019: GET /settings tests."""
+
+    def test_shows_masked_token_and_source_when_stored(self):
+        """US2-AS1: Settings shows masked token + source + change form when source is stored."""
+        resolved = ResolvedCredential(
+            token="github_pat_abcdefghijklmnop1234",
+            source=CredentialSource.STORED,
+        )
+        app, _, _, _ = _create_test_app(
+            resolver_result=resolved, resolver_source=CredentialSource.STORED
+        )
+        client = TestClient(app)
+        response = client.get("/settings")
+
+        assert response.status_code == 200
+        # Masked token visible (suffix)
+        assert "1234" in response.text
+        # Full token NOT visible
+        assert "github_pat_abcdefghijklmnop1234" not in response.text
+        # Source shown
+        assert "Encrypted Store" in response.text
+        # Change form visible (submit button present)
+        assert 'action="/settings/rotate"' in response.text
+        assert "Save" in response.text
+
+    def test_disables_form_when_docker_secret(self):
+        """US2-AS4: Form disabled when source is docker_secret."""
+        resolved = ResolvedCredential(
+            token="github_pat_docker_secret_token1234",
+            source=CredentialSource.DOCKER_SECRET,
+        )
+        app, _, _, _ = _create_test_app(
+            resolver_result=resolved, resolver_source=CredentialSource.DOCKER_SECRET
+        )
+        client = TestClient(app)
+        response = client.get("/settings")
+
+        assert response.status_code == 200
+        # Source shown
+        assert "Docker" in response.text
+        # Change form NOT present
+        assert 'action="/settings/rotate"' not in response.text
+        # Externally managed explanation
+        assert "managed externally" in response.text
+
+    def test_disables_form_when_env_var(self):
+        """US2-AS4: Form disabled when source is env_var."""
+        resolved = ResolvedCredential(
+            token="github_pat_env_var_token1234",
+            source=CredentialSource.ENV_VAR,
+        )
+        app, _, _, _ = _create_test_app(
+            resolver_result=resolved, resolver_source=CredentialSource.ENV_VAR
+        )
+        client = TestClient(app)
+        response = client.get("/settings")
+
+        assert response.status_code == 200
+        # Source shown
+        assert "Environment Variable" in response.text
+        # Change form NOT present
+        assert 'action="/settings/rotate"' not in response.text
+        # Externally managed explanation
+        assert "managed externally" in response.text
+
+    def test_flash_message_rotated(self):
+        """?msg=rotated → flash message displayed."""
+        resolved = ResolvedCredential(
+            token="github_pat_abcdefghijklmnop1234",
+            source=CredentialSource.STORED,
+        )
+        app, _, _, _ = _create_test_app(
+            resolver_result=resolved, resolver_source=CredentialSource.STORED
+        )
+        client = TestClient(app)
+        response = client.get("/settings?msg=rotated")
+
+        assert response.status_code == 200
+        assert "Token rotated successfully" in response.text
+
+
+class TestPostSettingsRotate:
+    """T019: POST /settings/rotate tests."""
+
+    def test_valid_token_replaces_and_redirects(self):
+        """AC-5: Valid token → replaces old + redirects to /settings?msg=rotated."""
+        resolved = ResolvedCredential(
+            token="github_pat_old_token_abcd1234",
+            source=CredentialSource.STORED,
+        )
+        app, mock_store, _, mock_validator = _create_test_app(
+            resolver_result=resolved, resolver_source=CredentialSource.STORED
+        )
+        mock_validator.validate = AsyncMock()  # No exception = success
+
+        client = TestClient(app, follow_redirects=False)
+        response = client.post(
+            "/settings/rotate", data={"token": "github_pat_new_valid_token"}
+        )
+
+        assert response.status_code == 303
+        assert "/settings?msg=rotated" in response.headers["location"]
+        mock_store.store.assert_called_once_with("github_pat_new_valid_token")
+
+    def test_invalid_token_preserves_old_and_shows_error(self):
+        """US2-AS3: Invalid token → preserves old token + shows error."""
+        resolved = ResolvedCredential(
+            token="github_pat_old_token_abcd1234",
+            source=CredentialSource.STORED,
+        )
+        app, mock_store, _, mock_validator = _create_test_app(
+            resolver_result=resolved, resolver_source=CredentialSource.STORED
+        )
+        mock_validator.validate = AsyncMock(
+            side_effect=TokenValidationError(
+                "Classic PATs (ghp_) are not supported.", "format"
+            )
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/settings/rotate", data={"token": "ghp_bad_token"}
+        )
+
+        assert response.status_code == 200
+        assert "Classic PATs" in response.text
+        # Old token still shown (masked)
+        assert "1234" in response.text
+        # store.store() NOT called — old token preserved
+        mock_store.store.assert_not_called()
+
+    def test_rejected_when_source_is_docker_secret(self):
+        """Rotation rejected when source is docker_secret (externally managed)."""
+        resolved = ResolvedCredential(
+            token="github_pat_docker_secret_token1234",
+            source=CredentialSource.DOCKER_SECRET,
+        )
+        app, mock_store, _, mock_validator = _create_test_app(
+            resolver_result=resolved, resolver_source=CredentialSource.DOCKER_SECRET
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/settings/rotate", data={"token": "github_pat_new_token"}
+        )
+
+        assert response.status_code == 200
+        assert "managed externally" in response.text
+        mock_store.store.assert_not_called()
+
+    def test_rejected_when_source_is_env_var(self):
+        """Rotation rejected when source is env_var (externally managed)."""
+        resolved = ResolvedCredential(
+            token="github_pat_env_var_token1234",
+            source=CredentialSource.ENV_VAR,
+        )
+        app, mock_store, _, mock_validator = _create_test_app(
+            resolver_result=resolved, resolver_source=CredentialSource.ENV_VAR
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/settings/rotate", data={"token": "github_pat_new_token"}
+        )
+
+        assert response.status_code == 200
+        assert "managed externally" in response.text
+        mock_store.store.assert_not_called()
+
+
+class TestGetSettingsNoCredential:
+    """S-5: GET /settings with no credential configured."""
+
+    def test_renders_without_error_when_no_credential(self):
+        """Settings page renders successfully when no credential is configured."""
+        app, _, _, _ = _create_test_app(
+            resolver_result=None, resolver_source=CredentialSource.NONE
+        )
+        client = TestClient(app)
+        response = client.get("/settings")
+
+        assert response.status_code == 200
+        # Source should be "none"
+        assert "none" in response.text.lower()
+        # No rotation form should be visible (can_rotate is False)
+        assert 'action="/settings/rotate"' not in response.text
+
+
+class TestPostSetupOSError:
+    """I-1: POST /setup when store.store() raises OSError."""
+
+    def test_oserror_renders_error_not_500(self):
+        """Store failure renders friendly error message, not a raw 500."""
+        app, mock_store, _, mock_validator = _create_test_app(resolver_result=None)
+        mock_validator.validate = AsyncMock()  # Validation passes
+        mock_store.store.side_effect = OSError("Permission denied: /data/credential.enc")
+
+        client = TestClient(app)
+        response = client.post("/setup", data={"token": "github_pat_valid_token"})
+
+        assert response.status_code == 200
+        assert "/data/ volume is mounted and writable" in response.text
+        # Should NOT be a 500
+        assert response.status_code != 500
+
+    def test_oserror_logs_error(self, caplog):
+        """Store failure logs at ERROR level."""
+        app, mock_store, _, mock_validator = _create_test_app(resolver_result=None)
+        mock_validator.validate = AsyncMock()
+        mock_store.store.side_effect = OSError("No space left on device")
+
+        with caplog.at_level(logging.ERROR, logger="server.web_routes"):
+            client = TestClient(app)
+            client.post("/setup", data={"token": "github_pat_valid_token"})
+
+        assert any("Failed to persist credential" in r.message for r in caplog.records)
+
+
+class TestPostSettingsRotateOSError:
+    """I-1: POST /settings/rotate when store.store() raises OSError."""
+
+    def test_oserror_renders_error_not_500(self):
+        """Store failure during rotation renders friendly error, not a raw 500."""
+        resolved = ResolvedCredential(
+            token="github_pat_old_token_abcd1234",
+            source=CredentialSource.STORED,
+        )
+        app, mock_store, _, mock_validator = _create_test_app(
+            resolver_result=resolved, resolver_source=CredentialSource.STORED
+        )
+        mock_validator.validate = AsyncMock()
+        mock_store.store.side_effect = OSError("Read-only file system")
+
+        client = TestClient(app)
+        response = client.post(
+            "/settings/rotate", data={"token": "github_pat_new_valid_token"}
+        )
+
+        assert response.status_code == 200
+        assert "/data/ volume is mounted and writable" in response.text
+        # Old masked token still visible
+        assert "1234" in response.text
+
+    def test_oserror_logs_error(self, caplog):
+        """Store failure during rotation logs at ERROR level."""
+        resolved = ResolvedCredential(
+            token="github_pat_old_token_abcd1234",
+            source=CredentialSource.STORED,
+        )
+        app, mock_store, _, mock_validator = _create_test_app(
+            resolver_result=resolved, resolver_source=CredentialSource.STORED
+        )
+        mock_validator.validate = AsyncMock()
+        mock_store.store.side_effect = OSError("Disk quota exceeded")
+
+        with caplog.at_level(logging.ERROR, logger="server.web_routes"):
+            client = TestClient(app)
+            client.post(
+                "/settings/rotate", data={"token": "github_pat_new_valid_token"}
+            )
+
+        assert any("Failed to persist credential" in r.message for r in caplog.records)
+
+
+class TestLogging:
+    """I-4: Verify logging events at appropriate levels."""
+
+    def test_successful_setup_logs_info(self, caplog):
+        """Successful token storage logs info message."""
+        app, mock_store, _, mock_validator = _create_test_app(resolver_result=None)
+        mock_validator.validate = AsyncMock()
+
+        with caplog.at_level(logging.INFO, logger="server.web_routes"):
+            client = TestClient(app, follow_redirects=False)
+            client.post("/setup", data={"token": "github_pat_valid_token"})
+
+        assert any(
+            "Token stored successfully (source: setup wizard)" in r.message
+            for r in caplog.records
+        )
+
+    def test_successful_rotation_logs_info(self, caplog):
+        """Successful token rotation logs info message."""
+        resolved = ResolvedCredential(
+            token="github_pat_old_token_abcd1234",
+            source=CredentialSource.STORED,
+        )
+        app, mock_store, _, mock_validator = _create_test_app(
+            resolver_result=resolved, resolver_source=CredentialSource.STORED
+        )
+        mock_validator.validate = AsyncMock()
+
+        with caplog.at_level(logging.INFO, logger="server.web_routes"):
+            client = TestClient(app, follow_redirects=False)
+            client.post(
+                "/settings/rotate", data={"token": "github_pat_new_valid_token"}
+            )
+
+        assert any(
+            "Token rotated successfully" in r.message for r in caplog.records
+        )
+
+    def test_validation_failure_logs_warning(self, caplog):
+        """Validation failure logs warning with error_type (not the token)."""
+        app, _, _, mock_validator = _create_test_app(resolver_result=None)
+        mock_validator.validate = AsyncMock(
+            side_effect=TokenValidationError("Bad format", "format")
+        )
+
+        with caplog.at_level(logging.WARNING, logger="server.web_routes"):
+            client = TestClient(app)
+            client.post("/setup", data={"token": "ghp_bad_token"})
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("Token validation failed: format" in r.message for r in warning_records)
+        # Token must NOT appear in any log message
+        assert all("ghp_bad_token" not in r.message for r in caplog.records)
+
+    def test_rotation_rejected_logs_warning(self, caplog):
+        """Rotation rejection for external source logs warning."""
+        resolved = ResolvedCredential(
+            token="github_pat_docker_secret_token1234",
+            source=CredentialSource.DOCKER_SECRET,
+        )
+        app, _, _, _ = _create_test_app(
+            resolver_result=resolved, resolver_source=CredentialSource.DOCKER_SECRET
+        )
+
+        with caplog.at_level(logging.WARNING, logger="server.web_routes"):
+            client = TestClient(app)
+            client.post(
+                "/settings/rotate", data={"token": "github_pat_new_token"}
+            )
+
+        assert any(
+            "Rotation rejected: credential source is" in r.message
+            for r in caplog.records
+        )

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -133,6 +133,15 @@ class TestPostSetup:
         assert "Classic PATs" in response.text
         mock_store.store.assert_not_called()
 
+    def test_whitespace_stripped_before_store(self):
+        """Token whitespace is stripped before storing."""
+        app, mock_store, _, mock_validator = _create_test_app(resolver_result=None)
+        mock_validator.validate = AsyncMock()
+        client = TestClient(app, follow_redirects=False)
+        response = client.post("/setup", data={"token": "  github_pat_valid_token  \n"})
+        assert response.status_code in (302, 303)
+        mock_store.store.assert_called_once_with("github_pat_valid_token")
+
 
 class TestMaskToken:
     def test_masks_standard_token(self):
@@ -182,6 +191,12 @@ class TestMaskToken:
         from server.web_routes import mask_token
         assert mask_token(None) == ""
 
+    def test_very_short_unknown_token(self):
+        """mask_token handles very short tokens (<=4 chars) without known prefix."""
+        from server.web_routes import mask_token
+        assert mask_token("ab") == "..."
+        assert mask_token("abcd") == "..."
+
 
 class TestGetSettings:
     """T019: GET /settings tests."""
@@ -204,7 +219,7 @@ class TestGetSettings:
         # Full token NOT visible
         assert "github_pat_abcdefghijklmnop1234" not in response.text
         # Source shown
-        assert "Encrypted Store" in response.text
+        assert "Stored (encrypted)" in response.text
         # Change form visible (submit button present)
         assert 'action="/settings/rotate"' in response.text
         assert "Save" in response.text
@@ -353,6 +368,17 @@ class TestPostSettingsRotate:
         assert "managed externally" in response.text
         mock_store.store.assert_not_called()
 
+    def test_rotation_rejected_when_no_credential(self):
+        """Rotation rejected when no credential is configured."""
+        app, mock_store, _, _ = _create_test_app(
+            resolver_result=None, resolver_source=CredentialSource.NONE
+        )
+        client = TestClient(app)
+        response = client.post("/settings/rotate", data={"token": "github_pat_newtoken12345"})
+        assert response.status_code == 200
+        assert "managed externally" in response.text
+        mock_store.store.assert_not_called()
+
 
 class TestGetSettingsNoCredential:
     """S-5: GET /settings with no credential configured."""
@@ -366,8 +392,8 @@ class TestGetSettingsNoCredential:
         response = client.get("/settings")
 
         assert response.status_code == 200
-        # Source should be "none"
-        assert "none" in response.text.lower()
+        # Source should show "Not configured"
+        assert "not configured" in response.text.lower()
         # No rotation form should be visible (can_rotate is False)
         assert 'action="/settings/rotate"' not in response.text
 

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -17,7 +17,7 @@ Per contract: specs/002-credential-setup/contracts/web-routes.md
 from __future__ import annotations
 
 import logging
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -28,8 +28,7 @@ from server.token_validator import TokenValidationError
 
 def _create_test_app(resolver_result=None, resolver_source=CredentialSource.NONE):
     """Create a FastAPI test app with mocked dependencies."""
-    from server.web_routes import create_router, mask_token
-    from server.main import app as real_app
+    from server.web_routes import create_router
     from fastapi import FastAPI
     from fastapi.staticfiles import StaticFiles
     from fastapi.templating import Jinja2Templates

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -376,7 +376,7 @@ class TestPostSettingsRotate:
         client = TestClient(app)
         response = client.post("/settings/rotate", data={"token": "github_pat_newtoken12345"})
         assert response.status_code == 200
-        assert "managed externally" in response.text
+        assert "No token is configured" in response.text
         mock_store.store.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- **4 new server modules**: `credential_store` (Fernet encryption, atomic writes), `credential_resolver` (Docker secret > env var > stored priority), `token_validator` (format + GitHub auth + Copilot SDK validation with verbose diagnostic errors), `web_routes` (setup wizard, status page, settings/rotation)
- **Web UI**: Server-rendered Jinja2 with monospace dark theme — setup wizard for first-time PAT onboarding, credential status page, token rotation
- **Security**: Tokens never in plaintext in logs/errors/repr, Fernet encryption with `chmod 600` key, `127.0.0.1` binding, content denylist preserved
- **Infrastructure**: Docker named volume for `/data/`, `cryptography` dependency added

## Test Plan
- [x] 524 tests pass, 95% coverage, 0 warnings
- [x] All 9 acceptance criteria verified (AC-1 through AC-9)
- [x] All 5 edge cases covered (key loss, credential invalidation, SDK unavailable, whitespace stripping)
- [x] Security tests: token masking in repr/logs/errors, no plaintext leakage
- [x] Docker build + compose validated (T026/T027)
- [x] PR review: 4 specialized agents (code, errors, tests, types) — all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local web UI for credential setup, status and settings with masked token display, PRG flash messages, and in‑app rotation; multi-source resolution and server-side validation (format, GitHub probe, Copilot access).

* **Security**
  * Localhost-only binding, persistent data volume with owner-only permissions, encrypted on-disk credentials, secret-file support, strict masking and no-token-in-logs.

* **Documentation**
  * Full spec, contracts, plan, archival rounds, checklists and task/judge/status records added.

* **Tests**
  * Extensive test suites for resolver, store, validator, web routes and startup mappings.

* **Chores**
  * Added cryptography dependency and container/runtime adjustments for /data and secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->